### PR TITLE
monitoring: Don't probe timestamp by default

### DIFF
--- a/gcp/modules/monitoring/prober/variables.tf
+++ b/gcp/modules/monitoring/prober/variables.tf
@@ -86,15 +86,13 @@ locals {
   # Note: timestamp is not part of "all endpoints" as it may not be enabled
   all_endpoints_filter = format("metric.labels.endpoint = one_of(\"%s\")", join("\", \"", distinct(concat(var.rekor_probed_endpoints, var.fulcio_probed_endpoints))))
 
+  # Note: timestamp is not yet included in hosts by default
   hosts = [{
     host            = var.fulcio_url
     endpoint_filter = local.fulcio_endpoint_filter
     }, {
     host            = var.rekor_url
     endpoint_filter = local.rekor_endpoint_filter
-    }, {
-    host            = var.timestamp_url
-    endpoint_filter = local.timestamp_endpoint_filter
     }
   ]
 }


### PR DESCRIPTION
This fixes in an issue where `prober_data_absent_alert["http://timestamp-server.tsa-system.svc"]` currently gets enabled because timestamp is in the prober hosts list -- and we don't actually have timestamp running yet

I think it makes sense to to set the hosts variable in the environment configuration (based on what services the environment is running) in future, but for now avoid adding timestamp to services that will be probed by default.

