### PR TITLE
timestamp: Rename key resource

### DIFF
--- a/gcp/modules/sigstore/sigstore.tf
+++ b/gcp/modules/sigstore/sigstore.tf
@@ -285,9 +285,9 @@ module "timestamp" {
   count = var.timestamp.enabled ? 1 : 0
 
   // KMS
-  timestamp_keyring_name             = var.timestamp_keyring_name
-  timestamp_encryption_key_name      = var.timestamp_encryption_key_name
-  timestamp_intermediate_ca_key_name = var.timestamp_intermediate_ca_key_name
+  timestamp_keyring_name        = var.timestamp_keyring_name
+  timestamp_encryption_key_name = var.timestamp_encryption_key_name
+  timestamp_ca_key_name         = var.timestamp_ca_key_name
 
   dns_zone_name   = var.dns_zone_name
   dns_domain_name = var.dns_domain_name

--- a/gcp/modules/sigstore/variables.tf
+++ b/gcp/modules/sigstore/variables.tf
@@ -297,7 +297,7 @@ variable "timestamp_keyring_name" {
 variable "timestamp_encryption_key_name" {
   type        = string
   description = "Name of KMS key for encrypting Tink private key for Timestamp Authority."
-  default     = "timestamp-encryption-key"
+  default     = "timestamp-key-encryption-key"
 }
 
 variable "timestamp_ca_key_name" {

--- a/gcp/modules/sigstore/variables.tf
+++ b/gcp/modules/sigstore/variables.tf
@@ -300,10 +300,10 @@ variable "timestamp_encryption_key_name" {
   default     = "timestamp-encryption-key"
 }
 
-variable "timestamp_intermediate_ca_key_name" {
+variable "timestamp_ca_key_name" {
   type        = string
-  description = "Name of KMS key for intermediate CA for Timestamp Authority"
-  default     = "timestamp-intermediate-ca-key"
+  description = "Name of KMS key for self-signed CA for Timestamp Authority"
+  default     = "timestamp-ca-key"
 }
 
 variable "iam_members_to_roles" {

--- a/gcp/modules/timestamp/kms.tf
+++ b/gcp/modules/timestamp/kms.tf
@@ -47,8 +47,8 @@ resource "google_kms_crypto_key" "timestamp-encryption-key" {
   depends_on = [google_kms_key_ring.timestamp-keyring]
 }
 
-resource "google_kms_crypto_key" "timestamp-intermediate-ca-key" {
-  name     = var.timestamp_intermediate_ca_key_name
+resource "google_kms_crypto_key" "timestamp-ca-key" {
+  name     = var.timestamp_ca_key_name
   key_ring = google_kms_key_ring.timestamp-keyring.id
   purpose  = "ASYMMETRIC_SIGN"
   version_template {

--- a/gcp/modules/timestamp/kms.tf
+++ b/gcp/modules/timestamp/kms.tf
@@ -36,7 +36,7 @@ resource "google_kms_key_ring" "timestamp-keyring" {
   depends_on = [google_project_service.service]
 }
 
-resource "google_kms_crypto_key" "timestamp-encryption-key" {
+resource "google_kms_crypto_key" "timestamp-key-encryption-key" {
   name     = var.timestamp_encryption_key_name
   key_ring = google_kms_key_ring.timestamp-keyring.id
   # purpose defaults to symmetric encryption/decryption

--- a/gcp/modules/timestamp/variables.tf
+++ b/gcp/modules/timestamp/variables.tf
@@ -46,10 +46,10 @@ variable "timestamp_encryption_key_name" {
   default     = "timestamp-encryption-key"
 }
 
-variable "timestamp_intermediate_ca_key_name" {
+variable "timestamp_ca_key_name" {
   type        = string
-  description = "Name of KMS key for intermediate CA for Timestamp Authority"
-  default     = "timestamp-intermediate-ca-key"
+  description = "Name of KMS key for self-signed CA for Timestamp Authority"
+  default     = "timestamp-ca-key"
 }
 
 variable "kms_location" {

--- a/gcp/modules/timestamp/variables.tf
+++ b/gcp/modules/timestamp/variables.tf
@@ -43,7 +43,7 @@ variable "timestamp_keyring_name" {
 variable "timestamp_encryption_key_name" {
   type        = string
   description = "Name of KMS key for encrypting Tink private key for Timestamp Authority"
-  default     = "timestamp-encryption-key"
+  default     = "timestamp-key-encryption-key"
 }
 
 variable "timestamp_ca_key_name" {


### PR DESCRIPTION
Plan is to setup timestamp with a cert chain that contains a self signed root certificate and a signing certificate.
* Rename the ca key and variable so they do not claim to be "intermediate"
* rename the encryption key: there is nothing wrong with this name but the key exists on staging already in destroyed state. I'd like to avoid possible issue and use a new name (better ideas welcome too)

These changes may not be strictly speaking necessary (it's just name changes) but I figured it's useful to do now before we create the KMS resources for staging...