### PR TITLE
sigstore: unlink timestamp and monitoring.timestamp

### DIFF
--- a/gcp/modules/sigstore/sigstore.tf
+++ b/gcp/modules/sigstore/sigstore.tf
@@ -96,7 +96,7 @@ module "monitoring" {
   ctlog_url                = var.monitoring.ctlog_url
   notification_channel_ids = var.monitoring.notification_channel_ids
   create_slos              = var.create_slos
-  timestamp_enabled        = var.timestamp.enabled
+  timestamp_enabled        = var.monitoring.timestamp_enabled
 
   depends_on = [
     module.gke-cluster,

--- a/gcp/modules/sigstore/variables.tf
+++ b/gcp/modules/sigstore/variables.tf
@@ -130,6 +130,7 @@ variable "monitoring" {
     dex_url                  = string
     ctlog_url                = string
     notification_channel_ids = list(string)
+    timestamp_enabled        = bool
   })
   default = {
     enabled                  = false
@@ -139,6 +140,7 @@ variable "monitoring" {
     dex_url                  = "oauth2.example.com"
     ctlog_url                = "ctlog.example.com"
     notification_channel_ids = []
+    timestamp_enabled        = false
   }
 }
 


### PR DESCRIPTION
Something is preventing overriding variable value for `monitoring.timestamp_enabled` later on: unlink it from `timestamp.enabled` variable and make sure the sigstore module defines a separate `monitoring.timestamp_enabled` variable

CC @bobcallaway this is per your suggestion
