### PR TITLE
update name of k8s service account per helm chart

### DIFF
--- a/gcp/modules/timestamp/service_accounts.tf
+++ b/gcp/modules/timestamp/service_accounts.tf
@@ -24,7 +24,7 @@ resource "google_service_account" "timestamp-sa" {
 resource "google_service_account_iam_member" "gke_sa_iam_member_timestamp" {
   service_account_id = google_service_account.timestamp-sa.name
   role               = "roles/iam.workloadIdentityUser"
-  member             = "serviceAccount:${var.project_id}.svc.id.goog[tsa-system/timestamp-server]"
+  member             = "serviceAccount:${var.project_id}.svc.id.goog[tsa-system/tsa-server]"
   depends_on         = [google_service_account.timestamp-sa]
 }
 


### PR DESCRIPTION
name in helm chart is `tsa-server` not `timestamp-server`