### PR TITLE
Remove unneeded signerVerifier role from timestamp SA

### DIFF
--- a/gcp/modules/timestamp/service_accounts.tf
+++ b/gcp/modules/timestamp/service_accounts.tf
@@ -28,13 +28,6 @@ resource "google_service_account_iam_member" "gke_sa_iam_member_timestamp" {
   depends_on         = [google_service_account.timestamp-sa]
 }
 
-resource "google_project_iam_member" "timestamp_kms_signer_verifier_member" {
-  project    = var.project_id
-  role       = "roles/cloudkms.signerVerifier"
-  member     = "serviceAccount:${google_service_account.timestamp-sa.email}"
-  depends_on = [google_service_account.timestamp-sa]
-}
-
 // Decrypt encrypted Tink keyset to get signing key
 resource "google_project_iam_member" "timestamp_kms_decrypter_member" {
   project    = var.project_id


### PR DESCRIPTION
This was likely a leftover from when we had an asymmetric KMS key for signing timestamps. We only need the role to decrypt with a symmetric key, for Tink.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
