### PR TITLE
Make Spanner instance optional for tiles_tlog

### DIFF
--- a/gcp/modules/tiles_tlog/spanner.tf
+++ b/gcp/modules/tiles_tlog/spanner.tf
@@ -15,6 +15,7 @@
  */
 
 resource "google_spanner_instance" "tessera" {
+  count            = var.freeze_shard ? 0 : 1
   project          = var.project_id
   name             = "${var.shard_name}-${var.spanner_instance_name_suffix}"
   config           = "regional-${var.region}"
@@ -24,6 +25,7 @@ resource "google_spanner_instance" "tessera" {
 }
 
 resource "google_spanner_database" "sequencer" {
+  count      = var.freeze_shard ? 0 : 1
   project    = var.project_id
   name       = "sequencer"
   instance   = google_spanner_instance.tessera.name
@@ -31,6 +33,7 @@ resource "google_spanner_database" "sequencer" {
 }
 
 resource "google_spanner_database" "antispam" {
+  count      = var.freeze_shard ? 0 : 1
   project    = var.project_id
   name       = "antispam"
   instance   = google_spanner_instance.tessera.name
@@ -38,6 +41,7 @@ resource "google_spanner_database" "antispam" {
 }
 
 resource "google_spanner_instance_iam_member" "rekor_tiles_spanner_db_admin" {
+  count      = var.freeze_shard ? 0 : 1
   project    = var.project_id
   instance   = google_spanner_instance.tessera.name
   role       = "roles/spanner.databaseAdmin"

--- a/gcp/modules/tiles_tlog/variables.tf
+++ b/gcp/modules/tiles_tlog/variables.tf
@@ -42,13 +42,19 @@ variable "cluster_name" {
   default = ""
 }
 
-variable "spanner_instance_name_suffix" {
-  description = "base name for transparency log resources"
+variable "shard_name" {
+  description = "name of the log shard"
   type        = string
 }
 
-variable "shard_name" {
-  description = "name of the log shard"
+variable "freeze_shard" {
+  description = "whether the shard is frozen. Spanner instances will be scaled down."
+  type        = bool
+  default     = false
+}
+
+variable "spanner_instance_name_suffix" {
+  description = "base name for transparency log resources"
   type        = string
 }
 


### PR DESCRIPTION
Make the Spanner instance and associated resources optional, as it isn't needed for a frozen log shard.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
