### PR TITLE
Change gRPC healthcheck to test a TCP connection, add healthcheck logging

### DIFF
--- a/gcp/modules/tiles_tlog/network.tf
+++ b/gcp/modules/tiles_tlog/network.tf
@@ -75,7 +75,7 @@ resource "google_compute_health_check" "grpc_health_check" {
   healthy_threshold   = 2
   unhealthy_threshold = 2
 
-  grpc_health_check {
+  tcp_health_check {
     port_specification = "USE_SERVING_PORT"
   }
 }

--- a/gcp/modules/tiles_tlog/network.tf
+++ b/gcp/modules/tiles_tlog/network.tf
@@ -64,6 +64,10 @@ resource "google_compute_health_check" "http_health_check" {
     request_path       = var.service_health_check_path
     port_specification = "USE_SERVING_PORT"
   }
+
+  log_config {
+    enable = true
+  }
 }
 
 resource "google_compute_health_check" "grpc_health_check" {
@@ -77,6 +81,10 @@ resource "google_compute_health_check" "grpc_health_check" {
 
   tcp_health_check {
     port_specification = "USE_SERVING_PORT"
+  }
+
+  log_config {
+    enable = true
   }
 }
 


### PR DESCRIPTION
gRPC healthchecks on GCP fail with connection issues regarding IPV6. I'm not sure what the root cause is, but I have found documentation that gRPC is primarily for Cloud Mesh Service and that gRPC healthchecks don't support TLS, which we have enabled for routing between the load balancer and backend service. The documentation suggests just using TCP, which only checks for a valid connection.

Also added healthcheck logging. NEGs are spun up so infrequently that the additional logging can be enabled unconditionally.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
