### PR TITLE
support for argocd v3

### DIFF
--- a/gcp/modules/argocd/argocd.tf
+++ b/gcp/modules/argocd/argocd.tf
@@ -56,8 +56,8 @@ spec:
       data:
         url: "git@github.com:${var.github_repo}.git"
         name: "${var.argocd_repo_name}"
-        type: git
-        insecure: ${var.argocd_repo_insecure}
+        type: "git"
+        insecure: "${var.argocd_repo_insecure}"
   data:
   - secretKey: sshPrivateKey
     remoteRef:

--- a/gcp/modules/argocd/argocd.tf
+++ b/gcp/modules/argocd/argocd.tf
@@ -53,6 +53,11 @@ spec:
       metadata:
         labels:
           argocd.argoproj.io/secret-type: repository
+      data:
+        url: "git@github.com:${var.github_repo}.git"
+        name: "${var.argocd_repo_name}"
+        type: git
+        insecure: ${var.argocd_repo_insecure}
   data:
   - secretKey: sshPrivateKey
     remoteRef:

--- a/gcp/modules/argocd/variables.tf
+++ b/gcp/modules/argocd/variables.tf
@@ -53,6 +53,17 @@ variable "gcp_secret_name_ssh" {
   type        = string
 }
 
+variable "argocd_repo_insecure" {
+  description = "Whether to skip SSH host key checking for the repository connection."
+  type        = bool
+  default     = false
+}
+
+variable "argocd_repo_name" {
+  description = "The name of the repository in ArgoCD."
+  type        = string
+}
+
 variable "gcp_secret_name_slack_token" {
   description = "GCP Secret name that holds the slack token to argocd send notifications."
   type        = string


### PR DESCRIPTION
https://argo-cd.readthedocs.io/en/latest/operator-manual/upgrading/2.14-3.0/#removed-support-for-legacy-repo-config-in-argocd-cm

we need to specify things via a K8S secret for argocd v3+ isntead of within the argocd configMap