### PR TITLE
Fix name of rekorv2 metrics

### DIFF
--- a/gcp/modules/monitoring/rekorv2/metrics.tf
+++ b/gcp/modules/monitoring/rekorv2/metrics.tf
@@ -24,7 +24,7 @@ resource "google_logging_metric" "rekorv2_k8s_pod_restart_failing_container" {
     value_type  = "INT64"
   }
 
-  name    = "rekorv2/k8s_pod/restarting-failed-container"
+  name    = "rekorv2-${var.shard_name}/k8s_pod/restarting-failed-container"
   project = var.project_id
 }
 
@@ -38,6 +38,6 @@ resource "google_logging_metric" "k8s_pod_unschedulable" {
     value_type  = "INT64"
   }
 
-  name    = "rekorv2/k8s_pod/unschedulable"
+  name    = "rekorv2-${var.shard_name}/k8s_pod/unschedulable"
   project = var.project_id
 }

--- a/gcp/modules/monitoring/rekorv2/rekorv2_alerts.tf
+++ b/gcp/modules/monitoring/rekorv2/rekorv2_alerts.tf
@@ -38,7 +38,7 @@ resource "google_monitoring_alert_policy" "rekorv2_k8s_pod_restart_failing_conta
       comparison              = "COMPARISON_GT"
       duration                = "600s"
       evaluation_missing_data = "EVALUATION_MISSING_DATA_NO_OP"
-      filter                  = "metric.type=\"logging.googleapis.com/user/rekorv2/k8s_pod/restarting-failed-container\" resource.type=\"k8s_pod\""
+      filter                  = "metric.type=\"logging.googleapis.com/user/${google_logging_metric.rekorv2_k8s_pod_restart_failing_container.name}\" resource.type=\"k8s_pod\""
       threshold_value         = "1"
 
       trigger {
@@ -83,7 +83,7 @@ resource "google_monitoring_alert_policy" "rekorv2_k8s_pod_unschedulable" {
 
       comparison      = "COMPARISON_GT"
       duration        = "600s"
-      filter          = "metric.type=\"logging.googleapis.com/user/rekorv2/k8s_pod/unschedulable\" resource.type=\"k8s_pod\""
+      filter          = "metric.type=\"logging.googleapis.com/user/${google_logging_metric.k8s_pod_unschedulable.name}\" resource.type=\"k8s_pod\""
       threshold_value = "1"
 
       trigger {


### PR DESCRIPTION
Use the unique shard name for the metric, which will be specific to the shard and its namespace. Then the alert can uniquely refer to that metric and not generally to any shard.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
