### PR TITLE
Set connection drain timeout for tiles_tlog

### DIFF
--- a/gcp/modules/tiles_tlog/network.tf
+++ b/gcp/modules/tiles_tlog/network.tf
@@ -123,7 +123,9 @@ resource "google_compute_backend_service" "k8s_http_backend_service" {
   load_balancing_scheme = "EXTERNAL_MANAGED"
   port_name             = "http"
   protocol              = "HTTP"
-  health_checks         = [google_compute_health_check.http_health_check[count.index].id]
+
+  connection_draining_timeout_sec = 15
+  health_checks                   = [google_compute_health_check.http_health_check[count.index].id]
 
   dynamic "backend" {
     for_each = data.google_compute_network_endpoint_group.k8s_http_neg
@@ -149,7 +151,9 @@ resource "google_compute_backend_service" "k8s_grpc_backend_service" {
   load_balancing_scheme = "EXTERNAL_MANAGED"
   port_name             = "grpc"
   protocol              = "HTTP2"
-  health_checks         = [google_compute_health_check.grpc_health_check[count.index].id]
+
+  connection_draining_timeout_sec = 15
+  health_checks                   = [google_compute_health_check.grpc_health_check[count.index].id]
 
   dynamic "backend" {
     for_each = data.google_compute_network_endpoint_group.k8s_grpc_neg


### PR DESCRIPTION
Connection draining[1] is recommended gives the external load balancer a grace period to drain connections from the application. The default timeout set by terraform is 300 seconds[2]. This is excessive considering the default termination grace period for a Kubernetes pod is 30 seconds, and a healthy Rekor request should last no more than 10 seconds. Set the timeout to 15 seconds to allow for a reasonably short termination period. The Kubernetes termination timeout will be updated as well.

[1] https://cloud.google.com/kubernetes-engine/docs/how-to/ingress-configuration#500-series-errors
[2] https://github.com/hashicorp/terraform-provider-google/issues/13478

Partial https://github.com/sigstore/rekor-tiles/issues/370
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
