### PR TITLE
Remove backend services from LB before shard turndown

### DIFF
--- a/gcp/modules/tiles_tlog/network.tf
+++ b/gcp/modules/tiles_tlog/network.tf
@@ -208,7 +208,7 @@ resource "google_compute_url_map" "url_map" {
     name            = var.shard_name
     default_service = google_compute_backend_bucket.tessera_backend_bucket.id
     dynamic "route_rules" {
-      for_each = var.freeze_shard ? [] : [1]
+      for_each = var.lb_backend_turndown ? [] : [1]
 
       content {
         priority = 1
@@ -219,7 +219,7 @@ resource "google_compute_url_map" "url_map" {
       }
     }
     dynamic "route_rules" {
-      for_each = var.freeze_shard ? [] : [1]
+      for_each = var.lb_backend_turndown ? [] : [1]
 
       content {
         priority = 2
@@ -244,7 +244,7 @@ resource "google_compute_url_map" "url_map" {
   }
 
   lifecycle {
-    create_before_destroy = true
+    prevent_destroy = true
   }
 }
 

--- a/gcp/modules/tiles_tlog/variables.tf
+++ b/gcp/modules/tiles_tlog/variables.tf
@@ -47,8 +47,16 @@ variable "shard_name" {
   type        = string
 }
 
+# Backend services must be removed from the load balancer before attempting to delete the backend services,
+# otherwise a resource-in-use error is thrown. Terraform isn't able to order operations, so the backend services must be removed first.
+variable "lb_backend_turndown" {
+  description = "whether to remove the K8s backends from the load balancer, when the shard is being turned down"
+  type        = bool
+  default     = false
+}
+
 variable "freeze_shard" {
-  description = "whether the shard is frozen. Spanner instances will be scaled down and KMS keys will be destroyed."
+  description = "whether the shard is frozen. Spanner, KMS and Compute resources will be deleted."
   type        = bool
   default     = false
 }


### PR DESCRIPTION
Terraform isn't smart enough to order the shard turndown such that the LB is updated before the backend services are deleted. Without this change, you'd get an error that the backend service resource is in use while trying to delete the service that's used by the LB.

The turndown procedure will be as follows:

1. Remove the monitoring module
2. Set the lb_backend_turndown flag to remove the K8s backends from the LB
3. Set network_endpoint_group_zones to \[\] so the NEGs are removed from the backends
4. Remove the K8s resources from the Helm charts, which will delete the NEGs
5. Set freeze_shard to delete the remaining GCP resources

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
