### PR TITLE
Append random ID to Tessera bucket name

### DIFF
--- a/gcp/modules/tiles_tlog/gcs.tf
+++ b/gcp/modules/tiles_tlog/gcs.tf
@@ -14,9 +14,13 @@
  * limitations under the License.
  */
 
+resource "random_id" "tessera_bucket_random_suffix" {
+  byte_length = var.bucket_id_length
+}
+
 resource "google_storage_bucket" "tessera_store" {
   project                     = var.project_id
-  name                        = "${var.shard_name}-${var.bucket_name_suffix}"
+  name                        = var.bucket_id_length == 0 ? format("%s-%s", var.shard_name, var.bucket_name_suffix) : format("%s-%s-%s", var.shard_name, var.bucket_name_suffix, random_id.tessera_bucket_random_suffix.hex)
   location                    = var.region
   storage_class               = var.storage_class
   uniform_bucket_level_access = true

--- a/gcp/modules/tiles_tlog/variables.tf
+++ b/gcp/modules/tiles_tlog/variables.tf
@@ -95,6 +95,12 @@ variable "bucket_name_suffix" {
   type        = string
 }
 
+variable "bucket_id_length" {
+  description = "length of random byte string to append to the bucket name. Appended as hex so ID length will be twice this value. GCS bucket name cannot be longer than 63 characters"
+  type        = number
+  default     = 10
+}
+
 variable "storage_class" {
   description = "storage class for the Tessera bucket"
   type        = string


### PR DESCRIPTION
Read traffic will be served from GCS through a CDN. The CDN requires that the bucket be public. Currently, the bucket name is predictable so the CDN could be bypassed. This makes the bucket name unguessable. For backwards compatibility, the ID length is configurable since we have two buckets in staging without random IDs.

Ref https://github.com/sigstore/rekor-tiles/issues/355

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
