### PR TITLE
Add TSA dashboards

### DIFF
--- a/gcp/modules/monitoring/infra/dashboards.tf
+++ b/gcp/modules/monitoring/infra/dashboards.tf
@@ -52,3 +52,9 @@ EOF
     google_monitoring_alert_policy.spanner_smoothed_cpu_utilization_warning
   ]
 }
+
+resource "google_monitoring_dashboard" "timestamp_authority_dashboard" {
+  project = var.project_id
+
+  dashboard_json = file("${path.module}/timestamp_authority.json")
+}

--- a/gcp/modules/monitoring/infra/timestamp_authority.json
+++ b/gcp/modules/monitoring/infra/timestamp_authority.json
@@ -1,0 +1,60 @@
+{
+  "displayName": "Timestamp Authority",
+  "mosaicLayout": {
+    "columns": 48,
+    "tiles": [
+      {
+        "height": 16,
+        "width": 24,
+        "widget": {
+          "title": "Mean API Latency over 1 minute",
+          "xyChart": {
+            "dataSets": [
+              {
+                "timeSeriesQuery": {
+                  "prometheusQuery": "(sum by (path) (rate(timestamp_authority_api_latency_sum[1m])) / sum by (path) (rate(timestamp_authority_api_latency_count[1m]))) / 1000000",
+                  "unitOverride": "ms"
+                }
+              }
+            ]
+          }
+        }
+      },
+      {
+        "xPos": 24,
+        "height": 16,
+        "width": 24,
+        "widget": {
+          "title": "Traffic",
+          "xyChart": {
+            "dataSets": [
+              {
+                "timeSeriesQuery": {
+                  "prometheusQuery": "sum by (\"path\")(rate({\"__name__\"=\"timestamp_authority_api_latency_summary_count\"}[${__interval}]))",
+                  "unitOverride": "1/s"
+                }
+              }
+            ]
+          }
+        }
+      },
+      {
+        "yPos": 16,
+        "height": 16,
+        "width": 24,
+        "widget": {
+          "title": "/api/v1/timestamp response codes",
+          "xyChart": {
+            "dataSets": [
+              {
+                "timeSeriesQuery": {
+                  "prometheusQuery": "sum by (\"code\")(rate({\"__name__\"=\"timestamp_authority_api_latency_summary_count\",\"path\"=\"/api/v1/timestamp\"}[${__interval}]))"
+                }
+              }
+            ]
+          }
+        }
+      }
+    ]
+  }
+}

--- a/gcp/modules/monitoring/timestamp/timestamp_alerts.tf
+++ b/gcp/modules/monitoring/timestamp/timestamp_alerts.tf
@@ -173,7 +173,7 @@ resource "google_monitoring_alert_policy" "signing_cert_expiration_alert" {
       }
     }
 
-    display_name = "Signing certificate expiration [MIN]"
+    display_name = "Timestamp Authority signing certificate expiration"
   }
 
   display_name = "Signing Cert Expiration"


### PR DESCRIPTION
This adds a basic dashboard for TSA:
<img width="3168" height="1734" alt="Screenshot From 2025-09-04 14-58-28" src="https://github.com/user-attachments/assets/182ef9df-c879-4e0c-a33b-97a62964f4e6" />

Happy to take suggestions if this set of widgets does not seem useful.

Details:
* I put the dashboard json in a separate file (if we move more dashboards here, `dashboards.tf` will become crowded). The downside of this is that the prometheus queries are a little annoying to edit as they need escaping -- this could be avoided by jsonencode and local tf variables but then using a separate file would be weird...
* The json is copy-paste from a exported clickops dashboard, cleaned manually (removed empty strings, empty arrays, empty objects and default values).
* There is also a naming change for an alert (so it's clear it's for TSA)