### PR TITLE
Add dashboard for client statistics

### DIFF
--- a/gcp/modules/monitoring/infra/clients.json
+++ b/gcp/modules/monitoring/infra/clients.json
@@ -1,0 +1,116 @@
+{
+  "displayName": "Clients",
+  "mosaicLayout": {
+    "columns": 48,
+    "tiles": [
+      {
+        "height": 20,
+        "width": 28,
+        "widget": {
+          "title": "Clients",
+          "pieChart": {
+            "chartType": "PIE",
+            "dataSets": [
+              {
+                "timeSeriesQuery": {
+                  "prometheusQuery": "sum by (client) (increase({__name__=\"logging.googleapis.com/user/tuf/client_user_agents\"}[7d]))"
+                }
+              }
+            ],
+            "sliceAggregatedThreshold": 0.5
+          }
+        }
+      },
+      {
+        "xPos": 28,
+        "height": 20,
+        "width": 13,
+        "widget": {
+          "text": {
+            "content": "These \"client marketshare\" numbers are based on parsing the user-agent header from requests to `timestamp.json` in the TUF repository. The assumption here is that clients -- whether they are signing or verifying -- make that request when starting up.\n",
+            "format": "MARKDOWN",
+            "style": {
+              "fontSize": "FS_LARGE",
+              "padding": "P_EXTRA_SMALL"
+            }
+          }
+        }
+      },
+      {
+        "yPos": 20,
+        "height": 14,
+        "width": 8,
+        "widget": {
+          "title": "sigstore-python versions",
+          "pieChart": {
+            "chartType": "PIE",
+            "dataSets": [
+              {
+                "timeSeriesQuery": {
+                  "prometheusQuery": "label_replace(\n  sum by (version) (increase({__name__=\"logging.googleapis.com/user/tuf/client_user_agents\", client=\"sigstore-python\"}[7d])),\n  \"version\",\n  \"unknown\",\n  \"version\",\n  \"^$\"\n)"
+                }
+              }
+            ]
+          }
+        }
+      },
+      {
+        "yPos": 20,
+        "xPos": 8,
+        "height": 14,
+        "width": 8,
+        "widget": {
+          "title": "sigstore-go versions",
+          "pieChart": {
+            "chartType": "PIE",
+            "dataSets": [
+              {
+                "timeSeriesQuery": {
+                  "prometheusQuery": "label_replace(\n  sum by (version) (increase({__name__=\"logging.googleapis.com/user/tuf/client_user_agents\", client=\"sigstore-go\"}[7d])),\n  \"version\",\n  \"unknown\",\n  \"version\",\n  \"^$\"\n)"
+                }
+              }
+            ]
+          }
+        }
+      },
+      {
+        "yPos": 20,
+        "xPos": 16,
+        "height": 14,
+        "width": 8,
+        "widget": {
+          "title": "cosign versions",
+          "pieChart": {
+            "chartType": "PIE",
+            "dataSets": [
+              {
+                "timeSeriesQuery": {
+                  "prometheusQuery": "label_replace(\n  sum by (version) (increase({__name__=\"logging.googleapis.com/user/tuf/client_user_agents\", client=\"cosign\"}[7d])),\n  \"version\",\n  \"unknown\",\n  \"version\",\n  \"^$\"\n)"
+                }
+              }
+            ]
+          }
+        }
+      },
+      {
+        "yPos": 20,
+        "xPos": 24,
+        "height": 14,
+        "width": 8,
+        "widget": {
+          "title": "sigstore-java versions",
+          "pieChart": {
+            "chartType": "PIE",
+            "dataSets": [
+              {
+                "timeSeriesQuery": {
+                  "prometheusQuery": "label_replace(\n  sum by (version) (increase({__name__=\"logging.googleapis.com/user/tuf/client_user_agents\", client=\"sigstoreJavaClient\"}[7d])),\n  \"version\",\n  \"unknown\",\n  \"version\",\n  \"^$\"\n)"
+                }
+              }
+            ]
+          }
+        }
+      }
+    ]
+  }
+}

--- a/gcp/modules/monitoring/infra/dashboards.tf
+++ b/gcp/modules/monitoring/infra/dashboards.tf
@@ -58,3 +58,9 @@ resource "google_monitoring_dashboard" "timestamp_authority_dashboard" {
 
   dashboard_json = file("${path.module}/timestamp_authority.json")
 }
+
+resource "google_monitoring_dashboard" "clients_dashboard" {
+  project = var.project_id
+
+  dashboard_json = file("${path.module}/clients.json")
+}


### PR DESCRIPTION
<img width="3246" height="1800" alt="Screenshot From 2025-09-08 12-10-59" src="https://github.com/user-attachments/assets/3a6aa5de-e800-40a8-a274-8bdb52e0aad6" />


* There is a significant amount of repetition in the dashboard definition (version charts are identical except for location and client name) but I feel it's still more maintainable this way than it would be if the client version chart json was generated with complex terraform code.
* This PR sort of depends on #90 (that adds the actual metric used here) -- I've kept this in a separate PR since that one already has a review.
* cosign data is missing in screenshot because cosign does not use tuf in staging. Adding other clients is easier once this exists in prod and we can see which clients should be added