### PR TITLE
Fix regex in client metric

### DIFF
--- a/gcp/modules/monitoring/tuf/metrics.tf
+++ b/gcp/modules/monitoring/tuf/metrics.tf
@@ -40,10 +40,10 @@ resource "google_logging_metric" "client_user_agents" {
 
   label_extractors = {
     "version" = <<-EOT
-      REGEXP_EXTRACT(httpRequest.userAgent, "[^\/s]+[/ ]v?(\d+\.\d+(?:\.\d+)?)")
+      REGEXP_EXTRACT(httpRequest.userAgent, "[^/\\s]+[/ ]v?(\\d+\\.\\d+(?:\\.\\d+)?)")
     EOT
     "client"  = <<-EOT
-      REGEXP_EXTRACT(httpRequest.userAgent, "^([^\/\s]+)")
+      REGEXP_EXTRACT(httpRequest.userAgent, "^([^/\\s]+)")
     EOT
   }
 }


### PR DESCRIPTION
The terraform apply for the new client metric failed.

Tweak the regexp escaping:
* escape `\` as `\\` -- this is for terraform: I originally thought terraform heredoc would not need this: it does
* Do not escape `/` -- GCP logging uses golang style regexp which does not require it: this also fixes an unrelated bug in the regex as "/s" now works as intended and not as literal "s"

There is no way to fully test this without TF apply but I have taken the expressions, unescaped them like I expect TF will, and fed them successfully to golang regexp tester.