### PR TITLE
Use the same machine type for autoscaling as our regular nodes

### DIFF
--- a/gcp/modules/gke_cluster/cluster.tf
+++ b/gcp/modules/gke_cluster/cluster.tf
@@ -148,6 +148,7 @@ resource "google_container_cluster" "cluster" {
     enabled             = var.cluster_autoscaling_enabled
 
     auto_provisioning_defaults {
+      machine_type    = var.node_config_machine_type
       service_account = google_service_account.gke-sa.email
       shielded_instance_config {
         enable_integrity_monitoring = true


### PR DESCRIPTION
We're running into CPU limits with the current machine type, e2-standard. Instead, have the autoscaler deploy the same machine type the other nodes use, which is default `n2-standard` and has higher CPU