### PR TITLE
Remove throttle, adaptive protection for edge security policy

### DIFF
--- a/gcp/modules/tiles_tlog/network.tf
+++ b/gcp/modules/tiles_tlog/network.tf
@@ -250,27 +250,6 @@ resource "google_compute_security_policy" "bucket_security_policy" {
   type    = "CLOUD_ARMOR_EDGE"
 
   rule {
-    action   = "throttle"
-    priority = "10"
-    match {
-      versioned_expr = "SRC_IPS_V1"
-      config {
-        src_ip_ranges = ["*"]
-      }
-    }
-    rate_limit_options {
-      enforce_on_key = "IP"
-      conform_action = "allow"
-      exceed_action  = "deny(429)"
-      rate_limit_threshold {
-        count        = var.bucket_qpm_rate_limit
-        interval_sec = "60"
-      }
-    }
-    description = "Rate limit all read traffic by client IP"
-  }
-
-  rule {
     action   = "allow"
     priority = "2147483647"
     match {
@@ -280,12 +259,6 @@ resource "google_compute_security_policy" "bucket_security_policy" {
       }
     }
     description = "default rule"
-  }
-
-  adaptive_protection_config {
-    layer_7_ddos_defense_config {
-      enable = var.enable_adaptive_protection
-    }
   }
 }
 


### PR DESCRIPTION
Per
https://cloud.google.com/armor/docs/security-policy-overview#policy-types, throttling and adaptive protection are not supported for edge security policies. Unfortunately I cannot find any other way to rate limit GCS that wouldn't involve serving the GCS content through a service like Cloud Run.

Leaving this policy in place even if there's no meaningful rules so that if we need to deny traffic, we can easily update the existing policy.

Fixes https://github.com/sigstore/public-good-instance/issues/3246

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
