### PR TITLE
Remove unused bucket QPM variable

### DIFF
--- a/gcp/modules/tiles_tlog/variables.tf
+++ b/gcp/modules/tiles_tlog/variables.tf
@@ -232,12 +232,6 @@ variable "http_grpc_qpm_rate_limit" {
   default     = 600 // 10 QPS
 }
 
-variable "bucket_qpm_rate_limit" {
-  description = "count of read requests per minute allowed to the GCS bucket"
-  type        = number
-  default     = 30000 // 500 QPS
-}
-
 variable "enable_adaptive_protection" {
   description = "whether to enable layer 7 DDoS adaptive protection"
   type        = bool


### PR DESCRIPTION
Forgot to remove this when removing the throttle policy for the backend bucket

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
