### PR TITLE
create initial dashboards for tiles lb

### DIFF
--- a/gcp/modules/monitoring/rekorv2/lb/dashboards.tf
+++ b/gcp/modules/monitoring/rekorv2/lb/dashboards.tf
@@ -1,0 +1,24 @@
+/**
+ * Copyright 2025 The Sigstore Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+resource "google_monitoring_dashboard" "rekor_v2_lb_dashboard" {
+  project = var.project_id
+
+  dashboard_json = templatefile("${path.module}/rekor_v2_lb.json.tpl", {
+    active_shards = var.active_shards
+    all_shards    = concat(var.active_shards, var.frozen_shards)
+  })
+}

--- a/gcp/modules/monitoring/rekorv2/lb/rekor_v2_lb.json.tpl
+++ b/gcp/modules/monitoring/rekorv2/lb/rekor_v2_lb.json.tpl
@@ -1,0 +1,88 @@
+{
+  "displayName": "Rekor v2 Requests",
+  "labels": {},
+  "gridLayout": {
+    "columns": 2,
+    "widgets": [
+%{ for shard in active_shards ~}
+      {
+        "title": "${shard} writes",
+        "xyChart": {
+          "chartOptions": {
+            "displayHorizontal": false,
+            "mode": "COLOR",
+            "showLegend": false
+          },
+          "dataSets": [
+          {
+            "minAlignmentPeriod": "60s",
+            "plotType": "STACKED_BAR",
+            "targetAxis": "Y1",
+            "timeSeriesQuery": {
+              "outputFullDuration": false,
+              "timeSeriesFilter": {
+                "aggregation": {
+                  "alignmentPeriod": "60s",
+                  "crossSeriesReducer": "REDUCE_SUM",
+                  "groupByFields": [
+                    "metric.label.\"response_code\""
+                  ],
+                  "perSeriesAligner": "ALIGN_RATE"
+                },
+                "filter": "metric.type=\"loadbalancing.googleapis.com/https/backend_request_count\" resource.type=\"https_lb_rule\" resource.label.\"forwarding_rule_name\"=monitoring.regex.full_match(\"${shard}-rekor-https-forwarding-rule\") resource.label.\"matched_url_path_rule\"=\"/api/v2/log/entries\""
+              }
+            }
+          }
+          ],
+          "yAxis": {
+            "scale": "LINEAR"
+          }
+        }
+      },
+%{ endfor ~}
+%{ for shard in all_shards ~}
+      {
+        "title": "${shard} reads",
+        "xyChart": {
+          "chartOptions": {
+            "displayHorizontal": false,
+            "mode": "COLOR",
+            "showLegend": false
+          },
+          "dataSets": [
+          {
+            "minAlignmentPeriod": "60s",
+            "plotType": "STACKED_BAR",
+            "targetAxis": "Y1",
+            "timeSeriesQuery": {
+              "outputFullDuration": false,
+              "timeSeriesFilter": {
+                "aggregation": {
+                  "alignmentPeriod": "60s",
+                  "crossSeriesReducer": "REDUCE_SUM",
+                  "groupByFields": [
+                    "metric.label.\"response_code\"",
+                  "metric.label.\"cache_result\""
+                  ],
+                  "perSeriesAligner": "ALIGN_RATE"
+                },
+                "filter": "metric.type=\"loadbalancing.googleapis.com/https/backend_request_count\" resource.type=\"https_lb_rule\" resource.label.\"forwarding_rule_name\"=monitoring.regex.full_match(\"${shard}-rekor-https-forwarding-rule\") resource.label.\"matched_url_path_rule\"=\"/api/v2/{path=**}\""
+              }
+            }
+          }
+          ],
+          "yAxis": {
+            "scale": "LINEAR"
+          }
+        }
+      },
+%{ endfor ~}
+      {
+        "title": "End",
+        "text": {
+          "content": "End"
+        }
+      }
+    ]
+  }
+}

--- a/gcp/modules/monitoring/rekorv2/lb/variables.tf
+++ b/gcp/modules/monitoring/rekorv2/lb/variables.tf
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2025 The Sigstore Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "project_id" {
+  type    = string
+  default = ""
+  validation {
+    condition     = length(var.project_id) > 0
+    error_message = "Must specify PROJECT_ID variable."
+  }
+}
+
+variable "project_number" {
+  type    = string
+  default = ""
+  validation {
+    condition     = length(var.project_number) > 0
+    error_message = "Must specify PROJECT_NUMBER variable."
+  }
+}
+
+variable "active_shards" {
+  type    = list(string)
+  default = []
+}
+
+variable "frozen_shards" {
+  type    = list(string)
+  default = []
+}

--- a/gcp/modules/monitoring/rekorv2/lb/versions.tf
+++ b/gcp/modules/monitoring/rekorv2/lb/versions.tf
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2025 The Sigstore Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+terraform {
+  required_version = "1.13.1"
+
+  required_providers {
+    google = {
+      version = "6.49.2"
+      source  = "hashicorp/google"
+    }
+  }
+}


### PR DESCRIPTION
Creates initial dashboards for the load balancer to watch reads/writes to rekor v2 shards

usage:
```
module "rekorv2_lb_monitoring" {
  source = "<path to here>"

  active_shards = ["log2025-alpha3"]
  frozen_shards = ["log2025-alpha1", "log2025-alpha2"]

  project_id = "potato"
  project_number = "..."
}

```

on an isolated terraform test instance, this seemed to work. The generated json is  valid dashboard.