### PR TITLE
Add prod dashboards for Rekor

### DIFF
--- a/gcp/modules/monitoring/infra/dashboards.tf
+++ b/gcp/modules/monitoring/infra/dashboards.tf
@@ -68,5 +68,7 @@ resource "google_monitoring_dashboard" "clients_dashboard" {
 resource "google_monitoring_dashboard" "rekor_v1" {
   project = var.project_id
 
-  dashboard_json = file("${path.module}/rekor_v1.json")
+  dashboard_json = templatefile("${path.module}/rekor_v1.json", {
+    rekor_url = var.rekor_url
+  })
 }

--- a/gcp/modules/monitoring/infra/rekor_v1.json
+++ b/gcp/modules/monitoring/infra/rekor_v1.json
@@ -4,6 +4,186 @@
     "columns": "2",
     "widgets": [
       {
+        "title": "Rekor API Response Codes",
+        "xyChart": {
+          "chartOptions": {
+            "mode": "COLOR"
+          },
+          "dataSets": [
+            {
+              "minAlignmentPeriod": "60s",
+              "plotType": "LINE",
+              "targetAxis": "Y1",
+              "timeSeriesQuery": {
+                "timeSeriesFilter": {
+                  "aggregation": {
+                    "alignmentPeriod": "60s",
+                    "crossSeriesReducer": "REDUCE_SUM",
+                    "groupByFields": [
+                      "metric.label.\"code\""
+                    ],
+                    "perSeriesAligner": "ALIGN_RATE"
+                  },
+                  "filter": "metric.type=\"prometheus.googleapis.com/rekor_api_latency_summary_count/summary\" resource.type=\"prometheus_target\""
+                }
+              }
+            }
+          ],
+          "timeshiftDuration": "0s",
+          "yAxis": {
+            "scale": "LINEAR"
+          }
+        }
+      },
+      {
+        "title": "New Log Entries",
+        "xyChart": {
+          "chartOptions": {
+            "mode": "COLOR"
+          },
+          "dataSets": [
+            {
+              "minAlignmentPeriod": "60s",
+              "plotType": "LINE",
+              "targetAxis": "Y1",
+              "timeSeriesQuery": {
+                "timeSeriesFilter": {
+                  "aggregation": {
+                    "alignmentPeriod": "60s",
+                    "crossSeriesReducer": "REDUCE_SUM",
+                    "groupByFields": [
+                      "resource.label.\"namespace\""
+                    ],
+                    "perSeriesAligner": "ALIGN_RATE"
+                  },
+                  "filter": "metric.type=\"prometheus.googleapis.com/rekor_new_entries/counter\" resource.type=\"prometheus_target\"",
+                  "secondaryAggregation": {
+                    "alignmentPeriod": "60s",
+                    "perSeriesAligner": "ALIGN_MEAN"
+                  }
+                }
+              }
+            }
+          ],
+          "timeshiftDuration": "0s",
+          "yAxis": {
+            "scale": "LINEAR"
+          }
+        }
+      },
+      {
+        "title": "API traffic by endpoint",
+        "xyChart": {
+          "chartOptions": {
+            "mode": "COLOR"
+          },
+          "dataSets": [
+            {
+              "minAlignmentPeriod": "60s",
+              "plotType": "LINE",
+              "targetAxis": "Y1",
+              "timeSeriesQuery": {
+                "timeSeriesFilter": {
+                  "aggregation": {
+                    "alignmentPeriod": "60s",
+                    "perSeriesAligner": "ALIGN_RATE"
+                  },
+                  "filter": "metric.type=\"prometheus.googleapis.com/rekor_api_latency_summary_count/summary\" resource.type=\"prometheus_target\"",
+                  "secondaryAggregation": {
+                    "crossSeriesReducer": "REDUCE_SUM",
+                    "groupByFields": [
+                      "metric.label.\"path\""
+                    ],
+                    "perSeriesAligner": "ALIGN_MEAN"
+                  }
+                }
+              }
+            }
+          ],
+          "timeshiftDuration": "0s",
+          "yAxis": {
+            "label": "y1Axis",
+            "scale": "LINEAR"
+          }
+        }
+      },
+      {
+        "title": "SQL Connection vs Load",
+        "xyChart": {
+          "chartOptions": {
+            "mode": "COLOR"
+          },
+          "dataSets": [
+            {
+              "minAlignmentPeriod": "60s",
+              "plotType": "LINE",
+              "targetAxis": "Y1",
+              "timeSeriesQuery": {
+                "timeSeriesFilter": {
+                  "aggregation": {
+                    "alignmentPeriod": "60s",
+                    "crossSeriesReducer": "REDUCE_SUM",
+                    "perSeriesAligner": "ALIGN_MEAN"
+                  },
+                  "filter": "metric.type=\"custom.googleapis.com/opencensus/trillian-cloudsql/cloudsqlconn/open_connections\" resource.type=\"global\""
+                }
+              }
+            },
+            {
+              "minAlignmentPeriod": "60s",
+              "plotType": "LINE",
+              "targetAxis": "Y1",
+              "timeSeriesQuery": {
+                "timeSeriesFilter": {
+                  "aggregation": {
+                    "alignmentPeriod": "60s",
+                    "crossSeriesReducer": "REDUCE_SUM",
+                    "perSeriesAligner": "ALIGN_MEAN"
+                  },
+                  "filter": "metric.type=\"custom.googleapis.com/opencensus/rekor-cloudsql/cloudsqlconn/open_connections\" resource.type=\"global\""
+                }
+              }
+            },
+            {
+              "minAlignmentPeriod": "60s",
+              "plotType": "LINE",
+              "targetAxis": "Y2",
+              "timeSeriesQuery": {
+                "timeSeriesFilter": {
+                  "aggregation": {
+                    "alignmentPeriod": "60s",
+                    "crossSeriesReducer": "REDUCE_SUM",
+                    "perSeriesAligner": "ALIGN_RATE"
+                  },
+                  "filter": "metric.type=\"prometheus.googleapis.com/rekor_new_entries/counter\" resource.type=\"prometheus_target\""
+                }
+              }
+            },
+            {
+              "minAlignmentPeriod": "60s",
+              "plotType": "LINE",
+              "targetAxis": "Y2",
+              "timeSeriesQuery": {
+                "timeSeriesFilter": {
+                  "aggregation": {
+                    "alignmentPeriod": "60s",
+                    "crossSeriesReducer": "REDUCE_SUM",
+                    "perSeriesAligner": "ALIGN_RATE"
+                  },
+                  "filter": "metric.type=\"prometheus.googleapis.com/rekor_qps_by_api/counter\" resource.type=\"prometheus_target\" metric.label.\"path\"=\"/api/v1/index/retrieve\""
+                }
+              }
+            }
+          ],
+          "y2Axis": {
+            "scale": "LINEAR"
+          },
+          "yAxis": {
+            "scale": "LINEAR"
+          }
+        }
+      },
+      {
         "title": "Mean of Rekor API Latency over 1 minute",
         "xyChart": {
           "chartOptions": {
@@ -36,7 +216,7 @@
               "plotType": "LINE",
               "targetAxis": "Y1",
               "timeSeriesQuery": {
-                "prometheusQuery": "max by (\"path\")(rate({\"__name__\"=\"rekor_api_latency_summary_sum\"}[${__interval}]))/ 1000000\n",
+                "prometheusQuery": "max by (\"path\")(rate({\"__name__\"=\"rekor_api_latency_summary_sum\"}[$${__interval}]))/ 1000000\n",
                 "unitOverride": "ms"
               }
             }
@@ -44,34 +224,6 @@
           "timeshiftDuration": "0s",
           "yAxis": {
             "label": "y1Axis",
-            "scale": "LINEAR"
-          }
-        }
-      },
-      {
-        "title": "prometheus/rekor_latency_by_api/histogram (filtered) [SUM]",
-        "xyChart": {
-          "chartOptions": {
-            "mode": "COLOR"
-          },
-          "dataSets": [
-            {
-              "minAlignmentPeriod": "60s",
-              "plotType": "HEATMAP",
-              "targetAxis": "Y1",
-              "timeSeriesQuery": {
-                "timeSeriesFilter": {
-                  "aggregation": {
-                    "alignmentPeriod": "60s",
-                    "crossSeriesReducer": "REDUCE_SUM",
-                    "perSeriesAligner": "ALIGN_DELTA"
-                  },
-                  "filter": "metric.type=\"prometheus.googleapis.com/rekor_latency_by_api/histogram\" resource.type=\"prometheus_target\" metric.label.\"path\"=\"/api/v1/log/entries/{entryUUID}\""
-                }
-              }
-            }
-          ],
-          "yAxis": {
             "scale": "LINEAR"
           }
         }
@@ -99,6 +251,44 @@
                     "perSeriesAligner": "ALIGN_RATE"
                   },
                   "filter": "metric.type=\"prometheus.googleapis.com/rekor_qps_by_api/counter\" resource.type=\"prometheus_target\""
+                }
+              }
+            }
+          ],
+          "yAxis": {
+            "scale": "LINEAR"
+          }
+        }
+      },
+      {
+        "title": "Rekor traffic by user agent",
+        "xyChart": {
+          "chartOptions": {
+            "mode": "COLOR"
+          },
+          "dataSets": [
+            {
+              "minAlignmentPeriod": "60s",
+              "plotType": "STACKED_BAR",
+              "targetAxis": "Y1",
+              "timeSeriesQuery": {
+                "timeSeriesFilter": {
+                  "aggregation": {
+                    "alignmentPeriod": "60s",
+                    "crossSeriesReducer": "REDUCE_SUM",
+                    "groupByFields": [
+                      "metric.label.\"userAgent\""
+                    ],
+                    "perSeriesAligner": "ALIGN_RATE"
+                  },
+                  "filter": "metric.type=\"logging.googleapis.com/user/Rekor-Traffic\" resource.type=\"l7_lb_rule\" metric.label.\"URL\"=monitoring.regex.full_match(\"http[s?]://${rekor_url}/api/v1/log/entries\")",
+                  "secondaryAggregation": {
+                    "crossSeriesReducer": "REDUCE_MEAN",
+                    "groupByFields": [
+                      "metric.label.\"userAgent\""
+                    ],
+                    "perSeriesAligner": "ALIGN_MEAN"
+                  }
                 }
               }
             }

--- a/gcp/modules/monitoring/rekor/metrics.tf
+++ b/gcp/modules/monitoring/rekor/metrics.tf
@@ -44,3 +44,41 @@ resource "google_logging_metric" "k8s_pod_unschedulable" {
   name    = "rekor/k8s_pod/unschedulable"
   project = var.project_id
 }
+
+resource "google_logging_metric" "rekor_traffic" {
+  description = "Load balancer traffic for Rekor"
+  filter      = "resource.type=\"http_load_balancer\"\nhttpRequest.requestUrl=~\"^https://${var.rekor_url}/"
+
+  metric_descriptor {
+    metric_kind = "DELTA"
+    unit        = "1"
+    value_type  = "INT64"
+    labels {
+      key = "userAgent"
+    }
+    labels {
+      key = "kind"
+    }
+    labels {
+      key = "method"
+    }
+    labels {
+      key = "URL"
+    }
+    labels {
+      key        = "code"
+      value_type = "INT64"
+    }
+  }
+
+  label_extractors = {
+    "URL"       = "EXTRACT(httpRequest.requestUrl)"
+    "code"      = "EXTRACT(httpRequest.status)"
+    "kind"      = "EXTRACT(protoPayload.request.kind)"
+    "method"    = "EXTRACT(httpRequest.requestMethod)"
+    "userAgent" = "EXTRACT(httpRequest.userAgent)"
+  }
+
+  name    = "Rekor-Traffic"
+  project = var.project_id
+}


### PR DESCRIPTION
The production environment had additional dashboards that were missed when the Rekor v1 dashboards were codified. This change updates the the dashboard JSON so that they match.

Added:
- Rekor-Traffic metric, which was hand-crafted in the production environment and is used for showing traffic by user agent
- Rekor API Response Codes dashboard
- New Log Entries dashboard
- API traffic by endpoint dashboard
- SQL Connection vs Load dashboard
- Rekor traffic by user agent (currently named "logging/user/Rekor-Traffic (filtered) [MEAN]" in prod)

Removed:
- prometheus/rekor_latency_by_api/histogram was filtering on the UUID entry read API and did not seem too useful, and was not present for the prod environment

Equivalent dashboards:
- Mean of Rekor API Latency over 1 minute dashboard

Staging dashboards being carried over:
- Max of Rekor API Latency Summary
- Requests per second by method and path

Partial https://github.com/sigstore/terraform-modules/issues/108
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
