### PR TITLE
Configure whether the K8s CPU utilization alert is enabled

### DIFF
--- a/gcp/modules/monitoring/infra/alerts.tf
+++ b/gcp/modules/monitoring/infra/alerts.tf
@@ -453,7 +453,7 @@ resource "google_monitoring_alert_policy" "k8s_container_cpu_allocatable_utiliza
     mime_type = "text/markdown"
   }
 
-  enabled               = "true"
+  enabled               = var.enable_k8s_cpu_utilization_alert
   notification_channels = local.notification_channels
   project               = var.project_id
 }

--- a/gcp/modules/monitoring/infra/variables.tf
+++ b/gcp/modules/monitoring/infra/variables.tf
@@ -40,6 +40,12 @@ variable "notification_channel_ids" {
   description = "List of notification channel IDs which alerts should be sent to. You can find this by running `gcloud alpha monitoring channels list`."
 }
 
+variable "enable_k8s_cpu_utilization_alert" {
+  type        = string
+  description = "whether to enable or disable the K8s CPU utilization alert"
+  default     = "true"
+}
+
 locals {
   notification_channels = toset([for nc in var.notification_channel_ids : format("projects/%v/notificationChannels/%v", var.project_id, nc)])
 }

--- a/gcp/modules/monitoring/sigstore.tf
+++ b/gcp/modules/monitoring/sigstore.tf
@@ -135,10 +135,11 @@ module "prober" {
 module "infra" {
   source = "./infra"
 
-  project_id               = var.project_id
-  notification_channel_ids = var.notification_channel_ids
-  rekor_url                = local.qualified_rekor_url
-  fulcio_url               = local.qualified_fulcio_url
+  project_id                       = var.project_id
+  notification_channel_ids         = var.notification_channel_ids
+  enable_k8s_cpu_utilization_alert = var.enable_k8s_cpu_utilization_alert
+  rekor_url                        = local.qualified_rekor_url
+  fulcio_url                       = local.qualified_fulcio_url
 
   depends_on = [
     google_project_service.service

--- a/gcp/modules/monitoring/variables.tf
+++ b/gcp/modules/monitoring/variables.tf
@@ -122,3 +122,9 @@ variable "timestamp_enabled" {
   type        = bool
   default     = false
 }
+
+variable "enable_k8s_cpu_utilization_alert" {
+  type        = string
+  description = "whether to enable or disable the K8s CPU utilization alert"
+  default     = "true"
+}

--- a/gcp/modules/sigstore/sigstore.tf
+++ b/gcp/modules/sigstore/sigstore.tf
@@ -84,20 +84,21 @@ module "monitoring" {
   // is disabled
   count = var.monitoring.enabled ? 1 : 0
 
-  project_id               = var.project_id
-  project_number           = var.project_number
-  cluster_location         = module.gke-cluster.cluster_location
-  cluster_name             = var.cluster_name
-  ca_pool_name             = var.ca_pool_name
-  fulcio_url               = var.monitoring.fulcio_url
-  rekor_url                = var.monitoring.rekor_url
-  timestamp_url            = var.monitoring.timestamp_url
-  dex_url                  = var.monitoring.dex_url
-  tuf_url                  = var.monitoring.tuf_url
-  ctlog_url                = var.monitoring.ctlog_url
-  notification_channel_ids = var.monitoring.notification_channel_ids
-  create_slos              = var.create_slos
-  timestamp_enabled        = var.monitoring.timestamp_enabled
+  project_id                       = var.project_id
+  project_number                   = var.project_number
+  cluster_location                 = module.gke-cluster.cluster_location
+  cluster_name                     = var.cluster_name
+  ca_pool_name                     = var.ca_pool_name
+  fulcio_url                       = var.monitoring.fulcio_url
+  rekor_url                        = var.monitoring.rekor_url
+  timestamp_url                    = var.monitoring.timestamp_url
+  dex_url                          = var.monitoring.dex_url
+  tuf_url                          = var.monitoring.tuf_url
+  ctlog_url                        = var.monitoring.ctlog_url
+  notification_channel_ids         = var.monitoring.notification_channel_ids
+  create_slos                      = var.create_slos
+  timestamp_enabled                = var.monitoring.timestamp_enabled
+  enable_k8s_cpu_utilization_alert = var.enable_k8s_cpu_utilization_alert
 
   depends_on = [
     module.gke-cluster,

--- a/gcp/modules/sigstore/variables.tf
+++ b/gcp/modules/sigstore/variables.tf
@@ -146,6 +146,12 @@ variable "monitoring" {
   }
 }
 
+variable "enable_k8s_cpu_utilization_alert" {
+  type        = string
+  description = "whether to enable or disable the K8s CPU utilization alert"
+  default     = "true"
+}
+
 variable "create_slos" {
   description = "Creates SLOs when true. (Monitoring must be enabled.)"
   type        = bool


### PR DESCRIPTION
This alert is currently noisy. Without this configuration, when we manually disable the alert and then run tf apply, the alert will be re-enabled.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
