### PR TITLE
Move health check firewall rule to gke_cluster

### DIFF
--- a/gcp/modules/gke_cluster/cluster.tf
+++ b/gcp/modules/gke_cluster/cluster.tf
@@ -218,3 +218,19 @@ resource "google_compute_firewall" "master-webhooks" {
 
   depends_on = [google_container_cluster.cluster]
 }
+
+// Services with terraform-managed load balancers (as opposed to Kubernetes Ingress-driven load balancers)
+// have health checks that originate from these specific IP ranges that need access to the container ports for the services (not the exposed service port).
+resource "google_compute_firewall" "healthcheck_firewall" {
+  name    = "gke-${var.cluster_name}-fw-allow-health-check-and-proxy"
+  project = var.project_id
+
+  network       = var.network
+  direction     = "INGRESS"
+  source_ranges = ["130.211.0.0/22", "35.191.0.0/16"]
+  target_tags   = [local.cluster_network_tag]
+  allow {
+    protocol = "tcp"
+    ports    = var.healthcheck_ports
+  }
+}

--- a/gcp/modules/gke_cluster/variables.tf
+++ b/gcp/modules/gke_cluster/variables.tf
@@ -240,3 +240,9 @@ variable "dns_control_plane_endpoint" {
   type        = bool
   default     = false
 }
+
+variable "healthcheck_ports" {
+  description = "List of ports that a healthcheck must be able to access through the firewall on the cluster."
+  type        = list(number)
+  default     = []
+}

--- a/gcp/modules/sigstore/sigstore.tf
+++ b/gcp/modules/sigstore/sigstore.tf
@@ -158,6 +158,7 @@ module "gke-cluster" {
   services_secondary_range_name = module.network.secondary_ip_range.1.range_name
   cluster_network_tag           = var.cluster_network_tag
   cluster_autoscaling_enabled   = var.cluster_autoscaling_enabled
+  healthcheck_ports             = var.healthcheck_ports
 
   initial_node_count   = var.initial_node_count
   autoscaling_min_node = var.autoscaling_min_node

--- a/gcp/modules/sigstore/variables.tf
+++ b/gcp/modules/sigstore/variables.tf
@@ -257,6 +257,12 @@ variable "gke_use_ip_endpoint" {
   default     = true
 }
 
+variable "healthcheck_ports" {
+  description = "List of ports that a healthcheck must be able to access through the firewall on the cluster."
+  type        = list(number)
+  default     = []
+}
+
 /********************************/
 /************ ACCESS ************/
 /********************************/

--- a/gcp/modules/tiles_tlog/network.tf
+++ b/gcp/modules/tiles_tlog/network.tf
@@ -14,10 +14,6 @@
  * limitations under the License.
  */
 
-locals {
-  cluster_network_tag = var.cluster_network_tag != "" ? var.cluster_network_tag : "gke-${var.cluster_name}"
-}
-
 resource "google_compute_global_address" "gce_lb_ipv4" {
   name         = "${var.shard_name}-${var.dns_subdomain_name}-${var.cluster_name}-gce-ext-lb"
   address_type = "EXTERNAL"
@@ -42,21 +38,6 @@ resource "google_dns_record_set" "A_tlog" {
 
   lifecycle {
     prevent_destroy = true
-  }
-}
-
-resource "google_compute_firewall" "backend_service_health_check" {
-  count   = var.freeze_shard ? 0 : 1
-  name    = "${var.shard_name}-${var.dns_subdomain_name}-fw-allow-health-check-and-proxy"
-  project = var.project_id
-
-  network       = var.network
-  direction     = "INGRESS"
-  source_ranges = ["130.211.0.0/22", "35.191.0.0/16"]
-  target_tags   = [local.cluster_network_tag]
-  allow {
-    protocol = "tcp"
-    ports    = var.network_endpoint_group_grpc_name_suffix == "" ? [var.http_service_port] : [var.http_service_port, var.grpc_service_port]
   }
 }
 

--- a/gcp/modules/tiles_tlog/variables.tf
+++ b/gcp/modules/tiles_tlog/variables.tf
@@ -168,18 +168,6 @@ variable "network" {
   default     = "default"
 }
 
-variable "http_service_port" {
-  description = "internal HTTP port for the transparency log service pod"
-  type        = string
-  default     = "3000"
-}
-
-variable "grpc_service_port" {
-  description = "internal gRPC port for the transparency log service pod"
-  type        = string
-  default     = "3001"
-}
-
 variable "service_health_check_path" {
   description = "HTTP URL request path for the service health check"
   type        = string
@@ -205,12 +193,6 @@ variable "http_read_path" {
 variable "http_read_rewrite_path" {
   description = "the template for the path to rewrite read requests to"
   type        = string
-  default     = ""
-}
-
-variable "cluster_network_tag" {
-  type        = string
-  description = "GKE cluster network tag for firewall"
   default     = ""
 }
 


### PR DESCRIPTION
All services with terraform-managed load balancers will need a firewall rule to allow health checks from two specific IP ranges. It is architecturally simpler and more resource-efficient to use one single firewall rule per cluster than to manage multiple firewall rules on a per-service basis.

This change will destroy the old firewall rule, so it is important when upgrading to ensure the resources are ordered such that the new one will be created before the old one is deleted.

Relates to https://github.com/sigstore/public-good-instance/issues/3603
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
