### PR TITLE
Add support for tink for fulcio

### DIFF
--- a/gcp/modules/fulcio/kms.tf
+++ b/gcp/modules/fulcio/kms.tf
@@ -37,12 +37,27 @@ resource "google_kms_key_ring" "fulcio-keyring" {
 }
 
 resource "google_kms_crypto_key" "fulcio-intermediate-key" {
+  count = var.ca_type == "kmsca" ? 1 : 0
+
   name     = var.fulcio_key_name
   key_ring = google_kms_key_ring.fulcio-keyring.id
   purpose  = "ASYMMETRIC_SIGN"
   version_template {
     algorithm        = "EC_SIGN_P384_SHA384"
     protection_level = "SOFTWARE"
+  }
+
+  depends_on = [google_kms_key_ring.fulcio-keyring]
+}
+
+resource "google_kms_crypto_key" "fulcio-key-encryption-key" {
+  count = var.ca_type == "tinkca" ? 1 : 0
+
+  name     = var.fulcio_encryption_key_name
+  key_ring = google_kms_key_ring.fulcio-keyring.id
+  # purpose defaults to symmetric encryption/decryption
+  lifecycle {
+    prevent_destroy = true
   }
 
   depends_on = [google_kms_key_ring.fulcio-keyring]

--- a/gcp/modules/fulcio/variables.tf
+++ b/gcp/modules/fulcio/variables.tf
@@ -64,6 +64,18 @@ variable "fulcio_key_name" {
   default     = "fulcio-intermediate-key"
 }
 
+variable "fulcio_encryption_key_name" {
+  type        = string
+  description = "Name of KMS key for encrypting Tink private key for Fulcio"
+  default     = "fulcio-key-encryption-key"
+}
+
+variable "ca_type" {
+  description = "What kind of CA Fulcio is running and therefore what kind of key to create. Possible values are 'kmsca' or 'tinkca'. Defaults to 'kmsca' which creates an asymmetric signing key. Use 'tinkca' to create a symmetric encryption/decryption key."
+  type        = string
+  default     = "kmsca"
+}
+
 variable "kms_location" {
   type        = string
   description = "Location of KMS keyring"


### PR DESCRIPTION
Conditionally create a symmetric key instead of asymmetric if using 'tinkca'.

Relates to https://github.com/sigstore/public-good-instance/issues/3603

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
