### PR TITLE
Avoid project level IAM for specific roles

### DIFF
--- a/gcp/modules/fulcio/service_accounts.tf
+++ b/gcp/modules/fulcio/service_accounts.tf
@@ -35,24 +35,24 @@ resource "google_project_iam_member" "fulcio_member" {
   depends_on = [google_service_account.fulcio-sa]
 }
 
-resource "google_project_iam_member" "fulcio_kms_signer_verifier_member" {
-  project    = var.project_id
-  role       = "roles/cloudkms.signerVerifier"
-  member     = "serviceAccount:${google_service_account.fulcio-sa.email}"
-  depends_on = [google_service_account.fulcio-sa]
+resource "google_kms_key_ring_iam_member" "fulcio_kms_signer_verifier_member" {
+  key_ring_id = google_kms_key_ring.fulcio-keyring.id
+  role        = "roles/cloudkms.signerVerifier"
+  member      = "serviceAccount:${google_service_account.fulcio-sa.email}"
+  depends_on  = [google_service_account.fulcio-sa]
 }
 
-resource "google_project_iam_member" "fulcio_kms_viewer_member" {
-  project    = var.project_id
-  role       = "roles/cloudkms.viewer"
-  member     = "serviceAccount:${google_service_account.fulcio-sa.email}"
-  depends_on = [google_service_account.fulcio-sa]
+resource "google_kms_key_ring_iam_member" "fulcio_kms_viewer_member" {
+  key_ring_id = google_kms_key_ring.fulcio-keyring.id
+  role        = "roles/cloudkms.viewer"
+  member      = "serviceAccount:${google_service_account.fulcio-sa.email}"
+  depends_on  = [google_service_account.fulcio-sa]
 }
 
 // Decrypt encrypted Tink keyset to get signing key
-resource "google_project_iam_member" "fulcio_kms_decrypter_member" {
-  project    = var.project_id
-  role       = "roles/cloudkms.cryptoKeyDecrypter"
-  member     = "serviceAccount:${google_service_account.fulcio-sa.email}"
-  depends_on = [google_service_account.fulcio-sa]
+resource "google_kms_key_ring_iam_member" "fulcio_kms_decrypter_member" {
+  key_ring_id = google_kms_key_ring.fulcio-keyring.id
+  role        = "roles/cloudkms.cryptoKeyDecrypter"
+  member      = "serviceAccount:${google_service_account.fulcio-sa.email}"
+  depends_on  = [google_service_account.fulcio-sa]
 }

--- a/gcp/modules/fulcio/service_accounts.tf
+++ b/gcp/modules/fulcio/service_accounts.tf
@@ -28,8 +28,10 @@ resource "google_service_account_iam_member" "gke_sa_iam_member_fulcio" {
   depends_on         = [google_service_account.fulcio-sa]
 }
 
-resource "google_project_iam_member" "fulcio_member" {
+resource "google_privateca_ca_pool_iam_member" "fulcio_member" {
   project    = var.project_id
+  location   = var.region
+  ca_pool    = var.ca_pool_name
   role       = "roles/privateca.certificateManager"
   member     = "serviceAccount:${google_service_account.fulcio-sa.email}"
   depends_on = [google_service_account.fulcio-sa]

--- a/gcp/modules/rekor/service_accounts.tf
+++ b/gcp/modules/rekor/service_accounts.tf
@@ -28,18 +28,18 @@ resource "google_service_account_iam_member" "gke_sa_iam_member_rekor" {
   depends_on         = [google_service_account.rekor-sa]
 }
 
-resource "google_project_iam_member" "rekor_signer_verifier_member" {
-  project    = var.project_id
-  role       = "roles/cloudkms.signerVerifier"
-  member     = "serviceAccount:${google_service_account.rekor-sa.email}"
-  depends_on = [google_service_account.rekor-sa]
+resource "google_kms_key_ring_iam_member" "rekor_signer_verifier_member" {
+  key_ring_id = google_kms_key_ring.rekor-keyring.id
+  role        = "roles/cloudkms.signerVerifier"
+  member      = "serviceAccount:${google_service_account.rekor-sa.email}"
+  depends_on  = [google_service_account.rekor-sa]
 }
 
-resource "google_project_iam_member" "rekor_kms_member" {
-  project    = var.project_id
-  role       = "roles/cloudkms.viewer"
-  member     = "serviceAccount:${google_service_account.rekor-sa.email}"
-  depends_on = [google_service_account.rekor-sa]
+resource "google_kms_key_ring_iam_member" "rekor_kms_member" {
+  key_ring_id = google_kms_key_ring.rekor-keyring.id
+  role        = "roles/cloudkms.viewer"
+  member      = "serviceAccount:${google_service_account.rekor-sa.email}"
+  depends_on  = [google_service_account.rekor-sa]
 }
 
 resource "google_project_iam_member" "rekor_profiler_agent" {

--- a/gcp/modules/tiles_tlog/kms.tf
+++ b/gcp/modules/tiles_tlog/kms.tf
@@ -35,18 +35,18 @@ resource "google_kms_crypto_key" "key_encryption_key" {
   depends_on = [google_kms_key_ring.keyring]
 }
 
-resource "google_project_iam_member" "decrypter" {
+resource "google_kms_key_ring_iam_member" "decrypter" {
   // Only needed if using KMS signer or when shard is active
-  count   = var.keyring_name_suffix == "" || var.freeze_shard ? 0 : 1
-  project = var.project_id
-  role    = "roles/cloudkms.cryptoKeyDecrypter"
-  member  = local.workload_iam_member_id
+  count       = var.keyring_name_suffix == "" || var.freeze_shard ? 0 : 1
+  key_ring_id = google_kms_key_ring.keyring[count.index].id
+  role        = "roles/cloudkms.cryptoKeyDecrypter"
+  member      = local.workload_iam_member_id
 }
 
-resource "google_project_iam_member" "kms_member" {
+resource "google_kms_key_ring_iam_member" "kms_member" {
   // Only needed if using KMS signer or when shard is active
-  count   = var.keyring_name_suffix == "" || var.freeze_shard ? 0 : 1
-  project = var.project_id
-  role    = "roles/cloudkms.viewer"
-  member  = local.workload_iam_member_id
+  count       = var.keyring_name_suffix == "" || var.freeze_shard ? 0 : 1
+  key_ring_id = google_kms_key_ring.keyring[count.index].id
+  role        = "roles/cloudkms.viewer"
+  member      = local.workload_iam_member_id
 }

--- a/gcp/modules/tiles_tlog/secret.tf
+++ b/gcp/modules/tiles_tlog/secret.tf
@@ -38,9 +38,18 @@ resource "google_secret_manager_secret" "public-key" {
   depends_on = [google_project_service.service]
 }
 
-resource "google_project_iam_member" "secret-getter" {
-  count   = var.enable_secrets ? 1 : 0
-  project = var.project_id
-  role    = "roles/secretmanager.secretAccessor"
-  member  = local.workload_iam_member_id
+resource "google_secret_manager_secret_iam_member" "private-secret-getter" {
+  count     = var.enable_secrets ? 1 : 0
+  project   = var.project_id
+  secret_id = google_secret_manager_secret.private-key[count.index].secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = local.workload_iam_member_id
+}
+
+resource "google_secret_manager_secret_iam_member" "public-secret-getter" {
+  count     = var.enable_secrets ? 1 : 0
+  project   = var.project_id
+  secret_id = google_secret_manager_secret.public-key[count.index].secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = local.workload_iam_member_id
 }

--- a/gcp/modules/timestamp/service_accounts.tf
+++ b/gcp/modules/timestamp/service_accounts.tf
@@ -29,16 +29,16 @@ resource "google_service_account_iam_member" "gke_sa_iam_member_timestamp" {
 }
 
 // Decrypt encrypted Tink keyset to get signing key
-resource "google_project_iam_member" "timestamp_kms_decrypter_member" {
-  project    = var.project_id
-  role       = "roles/cloudkms.cryptoKeyDecrypter"
-  member     = "serviceAccount:${google_service_account.timestamp-sa.email}"
-  depends_on = [google_service_account.timestamp-sa]
+resource "google_kms_key_ring_iam_member" "timestamp_kms_decrypter_member" {
+  key_ring_id = google_kms_key_ring.timestamp-keyring.id
+  role        = "roles/cloudkms.cryptoKeyDecrypter"
+  member      = "serviceAccount:${google_service_account.timestamp-sa.email}"
+  depends_on  = [google_service_account.timestamp-sa]
 }
 
-resource "google_project_iam_member" "timestamp_kms_viewer_member" {
-  project    = var.project_id
-  role       = "roles/cloudkms.viewer"
-  member     = "serviceAccount:${google_service_account.timestamp-sa.email}"
-  depends_on = [google_service_account.timestamp-sa]
+resource "google_kms_key_ring_iam_member" "timestamp_kms_viewer_member" {
+  key_ring_id = google_kms_key_ring.timestamp-keyring.id
+  role        = "roles/cloudkms.viewer"
+  member      = "serviceAccount:${google_service_account.timestamp-sa.email}"
+  depends_on  = [google_service_account.timestamp-sa]
 }


### PR DESCRIPTION
"google_project_iam_member" is not a good way to grant sensitive roles. Use more specific methods.
