### PR TITLE
Make attestation bucket optional

### DIFF
--- a/gcp/modules/rekor/storage.tf
+++ b/gcp/modules/rekor/storage.tf
@@ -34,6 +34,13 @@ resource "google_storage_bucket" "attestation" {
       log_bucket = var.gcs_logging_bucket
     }
   }
+
+  lifecycle {
+    precondition {
+      condition     = var.attestation_bucket != ""
+      error_message = "Must set attestation_bucket if enable_attestations is true"
+    }
+  }
 }
 
 // GCS Bucket 

--- a/gcp/modules/sigstore/variables.tf
+++ b/gcp/modules/sigstore/variables.tf
@@ -565,6 +565,7 @@ variable "attestation_region" {
 variable "attestation_bucket" {
   type        = string
   description = "Name of GCS bucket for attestation."
+  default     = ""
 }
 
 variable "attestation_storage_class" {


### PR DESCRIPTION
If Rekor v1 isn't deployed or if enable_attestations is false, the attestation bucket name does not need to be set.

Relates to https://github.com/sigstore/public-good-instance/issues/3603

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
