### PR TITLE
Make cloudsql monitoring optional

### DIFF
--- a/gcp/modules/monitoring/infra/alerts.tf
+++ b/gcp/modules/monitoring/infra/alerts.tf
@@ -68,6 +68,7 @@ resource "google_monitoring_alert_policy" "ssl_cert_expiry_alert" {
 
 # Cloud SQL Database CPU Utilization > 80%
 resource "google_monitoring_alert_policy" "cloud_sql_cpu_utilization_warning" {
+  count = var.cloudsql_enabled ? 1 : 0
   # In the absence of data, incident will auto-close in 7 days
   alert_strategy {
     auto_close = "604800s"
@@ -107,6 +108,7 @@ resource "google_monitoring_alert_policy" "cloud_sql_cpu_utilization_warning" {
 
 # Cloud SQL Database CPU Utilization > 90%
 resource "google_monitoring_alert_policy" "cloud_sql_cpu_utilization" {
+  count = var.cloudsql_enabled ? 1 : 0
   # In the absence of data, incident will auto-close in 7 days
   alert_strategy {
     auto_close = "604800s"
@@ -142,6 +144,7 @@ resource "google_monitoring_alert_policy" "cloud_sql_cpu_utilization" {
 
 # Cloud SQL Database Memory Utilization > 95%
 resource "google_monitoring_alert_policy" "cloud_sql_memory_utilization" {
+  count = var.cloudsql_enabled ? 1 : 0
   # In the absence of data, incident will auto-close in 7 days
   alert_strategy {
     auto_close = "604800s"
@@ -184,6 +187,7 @@ resource "google_monitoring_alert_policy" "cloud_sql_memory_utilization" {
 
 # Cloud SQL Database Disk has < 20GiB Free
 resource "google_monitoring_alert_policy" "cloud_sql_disk_utilization" {
+  count = var.cloudsql_enabled ? 1 : 0
   # In the absence of data, incident will auto-close in 7 days
   alert_strategy {
     auto_close = "604800s"
@@ -233,6 +237,7 @@ resource "google_monitoring_alert_policy" "cloud_sql_disk_utilization" {
 
 # Cloud SQL Proxy Connection Failures
 resource "google_monitoring_alert_policy" "cloudsqlconn_connection_failure" {
+  count = var.cloudsql_enabled ? 1 : 0
   # In the absence of data, incident will auto-close in 7 days
   alert_strategy {
     auto_close = "604800s"

--- a/gcp/modules/monitoring/infra/variables.tf
+++ b/gcp/modules/monitoring/infra/variables.tf
@@ -46,6 +46,12 @@ variable "enable_k8s_cpu_utilization_alert" {
   default     = "true"
 }
 
+variable "cloudsql_enabled" {
+  description = "Enable cloudsql monitoring"
+  type        = bool
+  default     = true
+}
+
 locals {
   notification_channels = toset([for nc in var.notification_channel_ids : format("projects/%v/notificationChannels/%v", var.project_id, nc)])
 }

--- a/gcp/modules/monitoring/sigstore.tf
+++ b/gcp/modules/monitoring/sigstore.tf
@@ -147,6 +147,7 @@ module "infra" {
   enable_k8s_cpu_utilization_alert = var.enable_k8s_cpu_utilization_alert
   rekor_url                        = local.qualified_rekor_url
   fulcio_url                       = local.qualified_fulcio_url
+  cloudsql_enabled                 = var.cloudsql_enabled
 
   depends_on = [
     google_project_service.service

--- a/gcp/modules/monitoring/variables.tf
+++ b/gcp/modules/monitoring/variables.tf
@@ -146,3 +146,9 @@ variable "uptime_check_period" {
   description = "The period (in seconds) between uptime checks"
   default     = "60s"
 }
+
+variable "cloudsql_enabled" {
+  description = "Enable cloudsql monitoring"
+  type        = bool
+  default     = true
+}

--- a/gcp/modules/sigstore/sigstore.tf
+++ b/gcp/modules/sigstore/sigstore.tf
@@ -114,6 +114,7 @@ module "monitoring" {
   ctlog_enabled                    = var.monitoring.ctlog_enabled
   enable_k8s_cpu_utilization_alert = var.enable_k8s_cpu_utilization_alert
   uptime_check_period              = var.monitoring.uptime_check_period
+  cloudsql_enabled                 = var.monitoring.cloudsql_enabled
 
   depends_on = [
     module.gke-cluster,

--- a/gcp/modules/sigstore/variables.tf
+++ b/gcp/modules/sigstore/variables.tf
@@ -151,6 +151,7 @@ variable "monitoring" {
     ctlog_enabled            = optional(bool, true)
     rekor_enabled            = optional(bool, true)
     uptime_check_period      = optional(string, "60s")
+    cloudsql_enabled         = optional(bool, true)
   })
   default = {
     enabled                  = false
@@ -165,6 +166,7 @@ variable "monitoring" {
     ctlog_enabled            = true
     rekor_enabled            = true
     uptime_check_period      = "60s"
+    cloudsql_enabled         = true
   }
 }
 


### PR DESCRIPTION
In a region where Cloud SQL isn't used, we don't need to monitor it.

Relates to https://github.com/sigstore/public-good-instance/issues/3603
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
