### PR TITLE
Use google_service_account.member when possible

### DIFF
--- a/gcp/modules/external_secrets/external_secrets.tf
+++ b/gcp/modules/external_secrets/external_secrets.tf
@@ -41,10 +41,9 @@ resource "google_service_account" "external_secrets_sa" {
 }
 
 resource "google_project_iam_member" "external_secrets_binding" {
-  project    = var.project_id
-  role       = "roles/secretmanager.secretAccessor"
-  member     = "serviceAccount:${google_service_account.external_secrets_sa.email}"
-  depends_on = [google_service_account.external_secrets_sa]
+  project = var.project_id
+  role    = "roles/secretmanager.secretAccessor"
+  member  = google_service_account.external_secrets_sa.member
 }
 
 resource "google_service_account_iam_member" "gke_sa_iam_member_external_secrets" {

--- a/gcp/modules/fulcio/service_accounts.tf
+++ b/gcp/modules/fulcio/service_accounts.tf
@@ -31,21 +31,18 @@ resource "google_service_account_iam_member" "gke_sa_iam_member_fulcio" {
 resource "google_kms_key_ring_iam_member" "fulcio_kms_signer_verifier_member" {
   key_ring_id = google_kms_key_ring.fulcio-keyring.id
   role        = "roles/cloudkms.signerVerifier"
-  member      = "serviceAccount:${google_service_account.fulcio-sa.email}"
-  depends_on  = [google_service_account.fulcio-sa]
+  member      = google_service_account.fulcio-sa.member
 }
 
 resource "google_kms_key_ring_iam_member" "fulcio_kms_viewer_member" {
   key_ring_id = google_kms_key_ring.fulcio-keyring.id
   role        = "roles/cloudkms.viewer"
-  member      = "serviceAccount:${google_service_account.fulcio-sa.email}"
-  depends_on  = [google_service_account.fulcio-sa]
+  member      = google_service_account.fulcio-sa.member
 }
 
 // Decrypt encrypted Tink keyset to get signing key
 resource "google_kms_key_ring_iam_member" "fulcio_kms_decrypter_member" {
   key_ring_id = google_kms_key_ring.fulcio-keyring.id
   role        = "roles/cloudkms.cryptoKeyDecrypter"
-  member      = "serviceAccount:${google_service_account.fulcio-sa.email}"
-  depends_on  = [google_service_account.fulcio-sa]
+  member      = google_service_account.fulcio-sa.member
 }

--- a/gcp/modules/gke_cluster/service_accounts.tf
+++ b/gcp/modules/gke_cluster/service_accounts.tf
@@ -32,7 +32,7 @@ resource "google_project_iam_member" "service-account" {
   ])
   project = var.project_id
   role    = each.key
-  member  = format("serviceAccount:%s", google_service_account.gke-sa.email)
+  member  = google_service_account.gke-sa.member
 }
 
 // Create the Prometheus service account
@@ -72,8 +72,7 @@ resource "google_project_iam_member" "prometheus_member" {
     "roles/monitoring.viewer",
     "roles/stackdriver.resourceMetadata.writer",
   ])
-  project    = var.project_id
-  role       = each.key
-  member     = "serviceAccount:${google_service_account.prometheus-sa.email}"
-  depends_on = [google_service_account.prometheus-sa]
+  project = var.project_id
+  role    = each.key
+  member  = google_service_account.prometheus-sa.member
 }

--- a/gcp/modules/mysql/mysql.tf
+++ b/gcp/modules/mysql/mysql.tf
@@ -64,10 +64,9 @@ resource "google_service_account" "dbuser_trillian" {
 
 // Attach cloudsql access permissions to the Google SA.
 resource "google_project_iam_member" "db_admin_member_trillian" {
-  project    = var.project_id
-  role       = "roles/cloudsql.client"
-  member     = "serviceAccount:${google_service_account.dbuser_trillian.email}"
-  depends_on = [google_service_account.dbuser_trillian]
+  project = var.project_id
+  role    = "roles/cloudsql.client"
+  member  = google_service_account.dbuser_trillian.member
 }
 
 resource "google_service_account_iam_member" "gke_sa_iam_member_trillian_logserver" {
@@ -86,10 +85,9 @@ resource "google_project_iam_member" "logserver_iam" {
     "roles/cloudsql.client",
     "roles/cloudtrace.agent"
   ])
-  project    = var.project_id
-  role       = each.key
-  member     = "serviceAccount:${google_service_account.dbuser_trillian.email}"
-  depends_on = [google_service_account.dbuser_trillian]
+  project = var.project_id
+  role    = each.key
+  member  = google_service_account.dbuser_trillian.member
 }
 
 resource "google_service_account_iam_member" "gke_sa_iam_member_trillian_logsigner" {
@@ -279,10 +277,9 @@ resource "google_sql_user" "iam_user" {
 }
 
 resource "google_project_iam_member" "db_iam_auth" {
-  project    = var.project_id
-  role       = "roles/cloudsql.instanceUser"
-  member     = "serviceAccount:${google_service_account.dbuser_trillian.email}"
-  depends_on = [google_service_account.dbuser_trillian]
+  project = var.project_id
+  role    = "roles/cloudsql.instanceUser"
+  member  = google_service_account.dbuser_trillian.member
 }
 
 resource "google_sql_user" "breakglass_iam_group" {

--- a/gcp/modules/rekor/kms.tf
+++ b/gcp/modules/rekor/kms.tf
@@ -36,6 +36,5 @@ resource "google_kms_crypto_key" "rekor-key" {
 resource "google_kms_key_ring_iam_member" "rekor_sa_kms_iam" {
   key_ring_id = google_kms_key_ring.rekor-keyring.id
   role        = "roles/cloudkms.viewer"
-  member      = format("serviceAccount:%s-rekor-sa@%s.iam.gserviceaccount.com", var.cluster_name, var.project_id)
-  depends_on  = [google_kms_key_ring.rekor-keyring, google_service_account.rekor-sa]
+  member      = google_service_account.rekor-sa.member
 }

--- a/gcp/modules/rekor/service_accounts.tf
+++ b/gcp/modules/rekor/service_accounts.tf
@@ -31,22 +31,19 @@ resource "google_service_account_iam_member" "gke_sa_iam_member_rekor" {
 resource "google_kms_key_ring_iam_member" "rekor_signer_verifier_member" {
   key_ring_id = google_kms_key_ring.rekor-keyring.id
   role        = "roles/cloudkms.signerVerifier"
-  member      = "serviceAccount:${google_service_account.rekor-sa.email}"
-  depends_on  = [google_service_account.rekor-sa]
+  member      = google_service_account.rekor-sa.member
 }
 
 resource "google_kms_key_ring_iam_member" "rekor_kms_member" {
   key_ring_id = google_kms_key_ring.rekor-keyring.id
   role        = "roles/cloudkms.viewer"
-  member      = "serviceAccount:${google_service_account.rekor-sa.email}"
-  depends_on  = [google_service_account.rekor-sa]
+  member      = google_service_account.rekor-sa.member
 }
 
 resource "google_project_iam_member" "rekor_profiler_agent" {
-  project    = var.project_id
-  role       = "roles/cloudprofiler.agent"
-  member     = "serviceAccount:${google_service_account.rekor-sa.email}"
-  depends_on = [google_service_account.rekor-sa]
+  project = var.project_id
+  role    = "roles/cloudprofiler.agent"
+  member  = google_service_account.rekor-sa.member
 }
 
 resource "google_service_account_iam_member" "gke_sa_iam_member_rekor_server" {
@@ -64,8 +61,7 @@ resource "google_project_iam_member" "logserver_iam" {
     "roles/stackdriver.resourceMetadata.writer",
     "roles/cloudtrace.agent"
   ])
-  project    = var.project_id
-  role       = each.key
-  member     = "serviceAccount:${google_service_account.rekor-sa.email}"
-  depends_on = [google_service_account.rekor-sa]
+  project = var.project_id
+  role    = each.key
+  member  = google_service_account.rekor-sa.member
 }

--- a/gcp/modules/rekor/sql.tf
+++ b/gcp/modules/rekor/sql.tf
@@ -29,17 +29,15 @@ resource "google_sql_user" "iam_user" {
 }
 
 resource "google_project_iam_member" "db_admin_member_rekor" {
-  project    = var.project_id
-  role       = "roles/cloudsql.client"
-  member     = "serviceAccount:${google_service_account.rekor-sa.email}"
-  depends_on = [google_service_account.rekor-sa]
+  project = var.project_id
+  role    = "roles/cloudsql.client"
+  member  = google_service_account.rekor-sa.member
 }
 
 resource "google_project_iam_member" "db_iam_auth" {
-  project    = var.project_id
-  role       = "roles/cloudsql.instanceUser"
-  member     = "serviceAccount:${google_service_account.rekor-sa.email}"
-  depends_on = [google_service_account.rekor-sa]
+  project = var.project_id
+  role    = "roles/cloudsql.instanceUser"
+  member  = google_service_account.rekor-sa.member
 }
 
 /*

--- a/gcp/modules/rekor/storage.tf
+++ b/gcp/modules/rekor/storage.tf
@@ -45,9 +45,8 @@ resource "google_storage_bucket" "attestation" {
 
 // GCS Bucket 
 resource "google_storage_bucket_iam_member" "rekor_gcs_member" {
-  count      = var.enable_attestations ? 1 : 0
-  bucket     = google_storage_bucket.attestation[count.index].name
-  role       = "roles/storage.objectAdmin"
-  member     = "serviceAccount:${google_service_account.rekor-sa.email}"
-  depends_on = [google_storage_bucket.attestation, google_service_account.rekor-sa]
+  count  = var.enable_attestations ? 1 : 0
+  bucket = google_storage_bucket.attestation[count.index].name
+  role   = "roles/storage.objectAdmin"
+  member = google_service_account.rekor-sa.member
 }

--- a/gcp/modules/timestamp/service_accounts.tf
+++ b/gcp/modules/timestamp/service_accounts.tf
@@ -32,13 +32,11 @@ resource "google_service_account_iam_member" "gke_sa_iam_member_timestamp" {
 resource "google_kms_key_ring_iam_member" "timestamp_kms_decrypter_member" {
   key_ring_id = google_kms_key_ring.timestamp-keyring.id
   role        = "roles/cloudkms.cryptoKeyDecrypter"
-  member      = "serviceAccount:${google_service_account.timestamp-sa.email}"
-  depends_on  = [google_service_account.timestamp-sa]
+  member      = google_service_account.timestamp-sa.member
 }
 
 resource "google_kms_key_ring_iam_member" "timestamp_kms_viewer_member" {
   key_ring_id = google_kms_key_ring.timestamp-keyring.id
   role        = "roles/cloudkms.viewer"
-  member      = "serviceAccount:${google_service_account.timestamp-sa.email}"
-  depends_on  = [google_service_account.timestamp-sa]
+  member      = google_service_account.timestamp-sa.member
 }

--- a/gcp/modules/tuf/kms.tf
+++ b/gcp/modules/tuf/kms.tf
@@ -42,8 +42,7 @@ resource "google_kms_crypto_key_version" "tuf-key-version" {
 resource "google_kms_key_ring_iam_member" "tuf-sa-key-iam" {
   key_ring_id = google_kms_key_ring.tuf-keyring.id
   role        = "roles/cloudkms.signerVerifier"
-  member      = format("serviceAccount:%s@%s.iam.gserviceaccount.com", var.tuf_service_account_name, var.project_id)
-  depends_on  = [google_kms_key_ring.tuf-keyring, google_service_account.tuf-sa]
+  member      = google_service_account.tuf-sa.member
 }
 
 resource "google_kms_key_ring_iam_member" "tuf-key-iam-viewers" {
@@ -52,5 +51,4 @@ resource "google_kms_key_ring_iam_member" "tuf-key-iam-viewers" {
   key_ring_id = google_kms_key_ring.tuf-keyring.id
   role        = "roles/cloudkms.publicKeyViewer"
   member      = each.key
-  depends_on  = [google_kms_key_ring.tuf-keyring]
 }

--- a/gcp/modules/tuf/tuf.tf
+++ b/gcp/modules/tuf/tuf.tf
@@ -91,7 +91,5 @@ resource "google_storage_bucket_iam_member" "tuf_sa_editor" {
 
   bucket = google_storage_bucket.tuf.name
   role   = each.key
-  member = format("serviceAccount:%s@%s.iam.gserviceaccount.com", var.tuf_service_account_name, var.project_id)
-
-  depends_on = [google_storage_bucket.tuf, google_service_account.tuf-sa]
+  member = google_service_account.tuf-sa.member
 }


### PR DESCRIPTION
Just a cleanup refactor: no functional change expected:
* No need to build the service account strings manually
* Also no need to depend explicitly if the resource is already referenced


Removal of `depends_on` is less code but is also based on docs that say _You should only use depends_on as a last resort because it can cause Terraform to create more conservative plans that replace more resources than necessary. For example, Terraform may treat more values as unknown "(known after apply)" because it is uncertain what changes will occur on the upstream object._ 

We could remove unnecessary "depends_on" elsewhere too but I kept this change limited to IAM memberships 