### PR TITLE
tuf: Create separate SAs for publish and sign

### DIFF
--- a/gcp/modules/sigstore/outputs.tf
+++ b/gcp/modules/sigstore/outputs.tf
@@ -126,3 +126,13 @@ output "bastion_kubectl" {
   value       = "HTTPS_PROXY=socks5://localhost:8118 kubectl get pods --all-namespaces"
 }
 
+output "tuf_signer_service_account_email" {
+  description = "TUF signer service account email"
+  value       = length(module.tuf) > 0 ? module.tuf[0].tuf_signer_service_account_email : ""
+}
+
+output "tuf_publisher_service_account_email" {
+  description = "TUF publisher service account email"
+  value       = length(module.tuf) > 0 ? module.tuf[0].tuf_publisher_service_account_email : ""
+}
+

--- a/gcp/modules/sigstore/sigstore.tf
+++ b/gcp/modules/sigstore/sigstore.tf
@@ -77,7 +77,9 @@ module "tuf" {
   storage_class       = var.tuf_storage_class
   main_page_suffix    = var.tuf_main_page_suffix
 
-  tuf_service_account_name = var.tuf_service_account_name
+  tuf_service_account_name           = var.tuf_service_account_name
+  tuf_signer_service_account_name    = var.tuf_signer_service_account_name
+  tuf_publisher_service_account_name = var.tuf_publisher_service_account_name
 
   tuf_keyring_name = var.tuf_keyring_name
   tuf_key_name     = var.tuf_key_name

--- a/gcp/modules/sigstore/variables.tf
+++ b/gcp/modules/sigstore/variables.tf
@@ -108,6 +108,18 @@ variable "tuf_service_account_name" {
   default     = "tuf-gha"
 }
 
+variable "tuf_signer_service_account_name" {
+  type        = string
+  description = "TUF signer service account name"
+  default     = "tuf-signer"
+}
+
+variable "tuf_publisher_service_account_name" {
+  type        = string
+  description = "TUF publisher service account name"
+  default     = "tuf-publisher"
+}
+
 variable "tuf_keyring_name" {
   type        = string
   description = "Name of KMS keyring for TUF metadata signing"

--- a/gcp/modules/tuf/kms.tf
+++ b/gcp/modules/tuf/kms.tf
@@ -31,12 +31,10 @@ resource "google_kms_crypto_key" "tuf-key" {
   lifecycle {
     prevent_destroy = true
   }
-  depends_on = [google_kms_key_ring.tuf-keyring]
 }
 
 resource "google_kms_crypto_key_version" "tuf-key-version" {
   crypto_key = google_kms_crypto_key.tuf-key.id
-  depends_on = [google_kms_crypto_key.tuf-key]
 }
 
 resource "google_kms_key_ring_iam_member" "tuf-sa-key-iam" {
@@ -46,11 +44,16 @@ resource "google_kms_key_ring_iam_member" "tuf-sa-key-iam" {
   depends_on  = [google_kms_key_ring.tuf-keyring, google_service_account.tuf-sa]
 }
 
+resource "google_kms_key_ring_iam_member" "tuf-signer-sa-key-iam" {
+  key_ring_id = google_kms_key_ring.tuf-keyring.id
+  role        = "roles/cloudkms.signerVerifier"
+  member      = google_service_account.tuf-signer-sa.member
+}
+
 resource "google_kms_key_ring_iam_member" "tuf-key-iam-viewers" {
   for_each = toset(var.tuf_key_viewers)
 
   key_ring_id = google_kms_key_ring.tuf-keyring.id
   role        = "roles/cloudkms.publicKeyViewer"
   member      = each.key
-  depends_on  = [google_kms_key_ring.tuf-keyring]
 }

--- a/gcp/modules/tuf/outputs.tf
+++ b/gcp/modules/tuf/outputs.tf
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2026 The Sigstore Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+output "tuf_signer_service_account_email" {
+  value       = google_service_account.tuf-signer-sa.email
+  description = "TUF signer service account email"
+}
+
+output "tuf_publisher_service_account_email" {
+  value       = google_service_account.tuf-publisher-sa.email
+  description = "TUF publisher service account email"
+}

--- a/gcp/modules/tuf/service_accounts.tf
+++ b/gcp/modules/tuf/service_accounts.tf
@@ -19,3 +19,15 @@ resource "google_service_account" "tuf-sa" {
   display_name = "TUF Service Account for GitHub Actions"
   project      = var.project_id
 }
+
+resource "google_service_account" "tuf-signer-sa" {
+  account_id   = var.tuf_signer_service_account_name
+  display_name = "TUF Signer Service Account for GitHub Actions"
+  project      = var.project_id
+}
+
+resource "google_service_account" "tuf-publisher-sa" {
+  account_id   = var.tuf_publisher_service_account_name
+  display_name = "TUF Publisher Service Account for GitHub Actions"
+  project      = var.project_id
+}

--- a/gcp/modules/tuf/tuf.tf
+++ b/gcp/modules/tuf/tuf.tf
@@ -95,3 +95,14 @@ resource "google_storage_bucket_iam_member" "tuf_sa_editor" {
 
   depends_on = [google_storage_bucket.tuf, google_service_account.tuf-sa]
 }
+
+resource "google_storage_bucket_iam_member" "tuf_publisher_sa_editor" {
+  for_each = toset([
+    "roles/storage.objectUser",
+    "roles/storage.legacyBucketReader"
+  ])
+
+  bucket = google_storage_bucket.tuf.name
+  role   = each.key
+  member = google_service_account.tuf-publisher-sa.member
+}

--- a/gcp/modules/tuf/variables.tf
+++ b/gcp/modules/tuf/variables.tf
@@ -65,6 +65,18 @@ variable "tuf_service_account_name" {
   default     = "tuf-gha"
 }
 
+variable "tuf_signer_service_account_name" {
+  type        = string
+  description = "TUF signer service account name"
+  default     = "tuf-signer"
+}
+
+variable "tuf_publisher_service_account_name" {
+  type        = string
+  description = "TUF publisher service account name"
+  default     = "tuf-publisher"
+}
+
 // KMS variables
 variable "tuf_keyring_name" {
   type        = string


### PR DESCRIPTION
* Separate SAs is cleaner and allows separate role bindings
* Keep the (now deprecated) "tuf-gha" SA in place to make sure transition is smooth: it can be removed once it's not used in any environment
* Remove unnecessary depends_on fields
* Add outputs for the new SA emails for easier use outside the module
