### PR TITLE
Make global metrics configurable

### DIFF
--- a/gcp/modules/monitoring/fulcio/metrics.tf
+++ b/gcp/modules/monitoring/fulcio/metrics.tf
@@ -18,6 +18,7 @@
 # Alerts specific to fulcio, rekor or dex should be in the appropriate `modules/monitoring/[service]` directory
 
 resource "google_logging_metric" "fulcio_k8s_pod_restart_failing_container" {
+  count       = var.create_logging_metrics ? 1 : 0
   description = "Counts the number of k8s_pod resource logs that contain the \"restarting failed container\" message"
   filter      = "resource.labels.namespace_name=\"fulcio-system\"\nresource.type=k8s_pod AND severity>=WARNING\n\"Back-off restarting failed container\"\n"
 
@@ -32,6 +33,7 @@ resource "google_logging_metric" "fulcio_k8s_pod_restart_failing_container" {
 }
 
 resource "google_logging_metric" "k8s_pod_unschedulable" {
+  count       = var.create_logging_metrics ? 1 : 0
   description = "Counts the number of k8s_pod resource logs that contain the unschedulable message"
   filter      = "resource.labels.namespace_name=\"fulcio-system\"\nresource.type=k8s_pod AND severity>=WARNING\n\"unschedulable\"\n"
 

--- a/gcp/modules/monitoring/fulcio/variables.tf
+++ b/gcp/modules/monitoring/fulcio/variables.tf
@@ -111,3 +111,9 @@ variable "uptime_check_period" {
   type    = string
   default = "60s"
 }
+
+variable "create_logging_metrics" {
+  description = "Whether to create logging metrics. Another instance of the monitoring module may already be managing logging metrics for this service."
+  type        = bool
+  default     = true
+}

--- a/gcp/modules/monitoring/sigstore.tf
+++ b/gcp/modules/monitoring/sigstore.tf
@@ -66,6 +66,7 @@ module "fulcio" {
   prober_url               = var.prober_fulcio_url
   create_slos              = var.create_slos
   uptime_check_period      = var.uptime_check_period
+  create_logging_metrics   = var.fulcio_create_logging_metrics
 
   depends_on = [
     google_project_service.service
@@ -87,6 +88,7 @@ module "timestamp" {
   prober_url               = var.prober_timestamp_url
   create_slos              = var.create_slos
   uptime_check_period      = var.uptime_check_period
+  create_logging_metrics   = var.timestamp_create_logging_metrics
 
   depends_on = [
     google_project_service.service
@@ -116,12 +118,18 @@ module "dex" {
 module "tuf" {
   source = "./tuf"
 
+  count = var.tuf_enabled ? 1 : 0
+
   project_id = var.project_id
   tuf_url    = var.tuf_url
 
   depends_on = [
     google_project_service.service
   ]
+}
+moved {
+  from = module.tuf
+  to   = module.tuf[0]
 }
 
 // Prober

--- a/gcp/modules/monitoring/timestamp/metrics.tf
+++ b/gcp/modules/monitoring/timestamp/metrics.tf
@@ -17,6 +17,7 @@
 # This file contains alerts for the Timestamp Authority service
 
 resource "google_logging_metric" "timestamp_k8s_pod_restart_failing_container" {
+  count       = var.create_logging_metrics ? 1 : 0
   description = "Counts the number of logs that contain the \"restarting failed container\" message"
   filter      = "resource.labels.namespace_name=\"tsa-system\"\nresource.type=k8s_pod AND severity>=WARNING\n\"Back-off restarting failed container\"\n"
 
@@ -31,6 +32,7 @@ resource "google_logging_metric" "timestamp_k8s_pod_restart_failing_container" {
 }
 
 resource "google_logging_metric" "k8s_pod_unschedulable" {
+  count       = var.create_logging_metrics ? 1 : 0
   description = "Counts the number of k8s_pod resource logs that contain the message \"unschedulable\""
   filter      = "resource.labels.namespace_name=\"tsa-system\"\nresource.type=k8s_pod AND severity>=WARNING\n\"unschedulable\"\n"
 

--- a/gcp/modules/monitoring/timestamp/variables.tf
+++ b/gcp/modules/monitoring/timestamp/variables.tf
@@ -84,3 +84,9 @@ variable "uptime_check_period" {
   type    = string
   default = "60s"
 }
+
+variable "create_logging_metrics" {
+  description = "Whether to create logging metrics. Another instance of the monitoring module may already be managing logging metrics for this service."
+  type        = bool
+  default     = true
+}

--- a/gcp/modules/monitoring/variables.tf
+++ b/gcp/modules/monitoring/variables.tf
@@ -135,6 +135,12 @@ variable "rekor_enabled" {
   default     = true
 }
 
+variable "tuf_enabled" {
+  description = "Enable TUF monitoring"
+  type        = bool
+  default     = true
+}
+
 variable "enable_k8s_cpu_utilization_alert" {
   type        = string
   description = "whether to enable or disable the K8s CPU utilization alert"
@@ -149,6 +155,18 @@ variable "uptime_check_period" {
 
 variable "cloudsql_enabled" {
   description = "Enable cloudsql monitoring"
+  type        = bool
+  default     = true
+}
+
+variable "fulcio_create_logging_metrics" {
+  description = "Whether to create logging metrics. Another instance of the monitoring module may already be managing logging metrics for this service."
+  type        = bool
+  default     = true
+}
+
+variable "timestamp_create_logging_metrics" {
+  description = "Whether to create logging metrics. Another instance of the monitoring module may already be managing logging metrics for this service."
   type        = bool
   default     = true
 }

--- a/gcp/modules/sigstore/sigstore.tf
+++ b/gcp/modules/sigstore/sigstore.tf
@@ -115,6 +115,9 @@ module "monitoring" {
   enable_k8s_cpu_utilization_alert = var.enable_k8s_cpu_utilization_alert
   uptime_check_period              = var.monitoring.uptime_check_period
   cloudsql_enabled                 = var.monitoring.cloudsql_enabled
+  tuf_enabled                      = var.monitoring.tuf_enabled
+  fulcio_create_logging_metrics    = var.monitoring.fulcio_create_logging_metrics
+  timestamp_create_logging_metrics = var.monitoring.timestamp_create_logging_metrics
 
   depends_on = [
     module.gke-cluster,

--- a/gcp/modules/sigstore/variables.tf
+++ b/gcp/modules/sigstore/variables.tf
@@ -139,34 +139,40 @@ variable "tuf_main_page_suffix" {
 variable "monitoring" {
   description = "Monitoring and alerting"
   type = object({
-    enabled                  = bool
-    fulcio_url               = string
-    rekor_url                = optional(string, "")
-    timestamp_url            = string
-    dex_url                  = string
-    tuf_url                  = string
-    ctlog_url                = optional(string, "")
-    notification_channel_ids = list(string)
-    timestamp_enabled        = bool
-    ctlog_enabled            = optional(bool, true)
-    rekor_enabled            = optional(bool, true)
-    uptime_check_period      = optional(string, "60s")
-    cloudsql_enabled         = optional(bool, true)
+    enabled                          = bool
+    fulcio_url                       = string
+    rekor_url                        = optional(string, "")
+    timestamp_url                    = string
+    dex_url                          = string
+    tuf_url                          = string
+    ctlog_url                        = optional(string, "")
+    notification_channel_ids         = list(string)
+    timestamp_enabled                = bool
+    ctlog_enabled                    = optional(bool, true)
+    rekor_enabled                    = optional(bool, true)
+    uptime_check_period              = optional(string, "60s")
+    cloudsql_enabled                 = optional(bool, true)
+    tuf_enabled                      = optional(bool, true)
+    fulcio_create_logging_metrics    = optional(bool, true)
+    timestamp_create_logging_metrics = optional(bool, true)
   })
   default = {
-    enabled                  = false
-    fulcio_url               = "fulcio.example.com"
-    rekor_url                = "rekor.example.com"
-    timestamp_url            = "timestamp.example.com"
-    dex_url                  = "oauth2.example.com"
-    tuf_url                  = "tuf.example.com"
-    ctlog_url                = "ctlog.example.com"
-    notification_channel_ids = []
-    timestamp_enabled        = false
-    ctlog_enabled            = true
-    rekor_enabled            = true
-    uptime_check_period      = "60s"
-    cloudsql_enabled         = true
+    enabled                          = false
+    fulcio_url                       = "fulcio.example.com"
+    rekor_url                        = "rekor.example.com"
+    timestamp_url                    = "timestamp.example.com"
+    dex_url                          = "oauth2.example.com"
+    tuf_url                          = "tuf.example.com"
+    ctlog_url                        = "ctlog.example.com"
+    notification_channel_ids         = []
+    timestamp_enabled                = false
+    ctlog_enabled                    = true
+    rekor_enabled                    = true
+    uptime_check_period              = "60s"
+    cloudsql_enabled                 = true
+    tuf_enabled                      = true
+    fulcio_create_logging_metrics    = true
+    timestamp_create_logging_metrics = true
   }
 }
 


### PR DESCRIPTION
Make the fulcio and timestamp logging metrics optional. These logging metrics have universal names and can be filtered and aggregated by any cluster or region, so they don't need to be recreated by another instance of the monitoring module.

TUF is also only deployed once, so do not configure a second monitoring instance for it.

Relates to https://github.com/sigstore/public-good-instance/issues/3603

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
