### PR TITLE
Fix moved resources names

### DIFF
--- a/gcp/modules/tiles_tlog/network.tf
+++ b/gcp/modules/tiles_tlog/network.tf
@@ -44,12 +44,12 @@ moved {
   to   = module.shared[0].google_compute_health_check.grpc_health_check
 }
 moved {
-  from = google_compute_security_policy.k8s_http_grpc_security_policy_renamed
-  to   = module.shared[0].google_compute_security_policy.k8s_http_grpc_security_policy_renamed
+  from = google_compute_security_policy.k8s_http_grpc_security_policy_renamed[0]
+  to   = module.shared[0].google_compute_security_policy.k8s_http_grpc_security_policy[0]
 }
 moved {
   from = google_compute_security_policy.bucket_security_policy_renamed
-  to   = module.shared[0].google_compute_security_policy.bucket_security_policy_renamed
+  to   = module.shared[0].google_compute_security_policy.bucket_security_policy
 }
 moved {
   from = google_compute_ssl_policy.ssl_policy


### PR DESCRIPTION
Fix the names of tiles_tlog resources that were moved so that they are not destroyed and recreated.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
