### PR TITLE
Remove tuf-gha service account

### DIFF
--- a/gcp/modules/sigstore/sigstore.tf
+++ b/gcp/modules/sigstore/sigstore.tf
@@ -77,7 +77,6 @@ module "tuf" {
   storage_class       = var.tuf_storage_class
   main_page_suffix    = var.tuf_main_page_suffix
 
-  tuf_service_account_name           = var.tuf_service_account_name
   tuf_signer_service_account_name    = var.tuf_signer_service_account_name
   tuf_publisher_service_account_name = var.tuf_publisher_service_account_name
 

--- a/gcp/modules/sigstore/variables.tf
+++ b/gcp/modules/sigstore/variables.tf
@@ -112,12 +112,6 @@ variable "tuf_storage_class" {
   default     = "REGIONAL"
 }
 
-variable "tuf_service_account_name" {
-  type        = string
-  description = "Name of service account for TUF signing on GitHub Actions"
-  default     = "tuf-gha"
-}
-
 variable "tuf_signer_service_account_name" {
   type        = string
   description = "TUF signer service account name"

--- a/gcp/modules/tuf/kms.tf
+++ b/gcp/modules/tuf/kms.tf
@@ -37,12 +37,6 @@ resource "google_kms_crypto_key_version" "tuf-key-version" {
   crypto_key = google_kms_crypto_key.tuf-key.id
 }
 
-resource "google_kms_key_ring_iam_member" "tuf-sa-key-iam" {
-  key_ring_id = google_kms_key_ring.tuf-keyring.id
-  role        = "roles/cloudkms.signerVerifier"
-  member      = google_service_account.tuf-sa.member
-}
-
 resource "google_kms_key_ring_iam_member" "tuf-signer-sa-key-iam" {
   key_ring_id = google_kms_key_ring.tuf-keyring.id
   role        = "roles/cloudkms.signerVerifier"

--- a/gcp/modules/tuf/service_accounts.tf
+++ b/gcp/modules/tuf/service_accounts.tf
@@ -14,12 +14,6 @@
  * limitations under the License.
  */
 
-resource "google_service_account" "tuf-sa" {
-  account_id   = var.tuf_service_account_name
-  display_name = "TUF Service Account for GitHub Actions"
-  project      = var.project_id
-}
-
 resource "google_service_account" "tuf-signer-sa" {
   account_id   = var.tuf_signer_service_account_name
   display_name = "TUF Signer Service Account for GitHub Actions"

--- a/gcp/modules/tuf/tuf.tf
+++ b/gcp/modules/tuf/tuf.tf
@@ -83,17 +83,6 @@ resource "google_storage_bucket_iam_member" "public_tuf_member" {
   depends_on = [google_storage_bucket.tuf]
 }
 
-resource "google_storage_bucket_iam_member" "tuf_sa_editor" {
-  for_each = toset([
-    "roles/storage.objectUser",
-    "roles/storage.legacyBucketReader"
-  ])
-
-  bucket = google_storage_bucket.tuf.name
-  role   = each.key
-  member = google_service_account.tuf-sa.member
-}
-
 resource "google_storage_bucket_iam_member" "tuf_publisher_sa_editor" {
   for_each = toset([
     "roles/storage.objectUser",

--- a/gcp/modules/tuf/variables.tf
+++ b/gcp/modules/tuf/variables.tf
@@ -58,13 +58,6 @@ variable "gcs_logging_bucket" {
   default     = ""
 }
 
-// Service account variables
-variable "tuf_service_account_name" {
-  type        = string
-  description = "Name of service account for TUF signing on GitHub Actions"
-  default     = "tuf-gha"
-}
-
 variable "tuf_signer_service_account_name" {
   type        = string
   description = "TUF signer service account name"


### PR DESCRIPTION
This is no longer used in public good instance: tuf-publisher and tuf-signer are used instead.
