### PR TITLE
Make fulcio and TSA SA names configurable

### DIFF
--- a/gcp/modules/fulcio/service_accounts.tf
+++ b/gcp/modules/fulcio/service_accounts.tf
@@ -14,9 +14,15 @@
  * limitations under the License.
  */
 
+locals {
+  // The cluster name may be too long to use as a part of a service account ID, which must be under 30 characters total.
+  service_account_prefix = var.service_account_prefix != "" ? var.service_account_prefix : var.cluster_name
+}
+
+
 // Create the Fulcio service account
 resource "google_service_account" "fulcio-sa" {
-  account_id   = format("%s-fulcio-sa", var.cluster_name)
+  account_id   = format("%s-fulcio-sa", local.service_account_prefix)
   display_name = "Fulcio Service Account"
   project      = var.project_id
 }

--- a/gcp/modules/fulcio/variables.tf
+++ b/gcp/modules/fulcio/variables.tf
@@ -39,6 +39,12 @@ variable "cluster_name" {
   type        = string
 }
 
+variable "service_account_prefix" {
+  description = "The prefix of the name of the GKE service accounts"
+  type        = string
+  default     = ""
+}
+
 // Certificate authority
 variable "ca_pool_name" {
   description = "Certificate authority pool name"

--- a/gcp/modules/gke_cluster/service_accounts.tf
+++ b/gcp/modules/gke_cluster/service_accounts.tf
@@ -15,6 +15,7 @@
  */
 
 locals {
+  // The cluster name may be too long to use as a part of a service account ID, which must be under 30 characters total.
   service_account_prefix = var.service_account_prefix != "" ? var.service_account_prefix : var.cluster_name
 }
 

--- a/gcp/modules/sigstore/sigstore.tf
+++ b/gcp/modules/sigstore/sigstore.tf
@@ -159,7 +159,7 @@ module "gke-cluster" {
   project_id = var.project_id
 
   cluster_name           = var.cluster_name
-  service_account_prefix = var.gke_service_account_prefix
+  service_account_prefix = var.service_account_prefix
 
   network                       = module.network.network_self_link
   subnetwork                    = module.network.subnetwork_self_link
@@ -294,9 +294,10 @@ module "rekor" {
 module "fulcio" {
   source = "../fulcio"
 
-  region       = var.region
-  project_id   = var.project_id
-  cluster_name = var.cluster_name
+  region                 = var.region
+  project_id             = var.project_id
+  cluster_name           = var.cluster_name
+  service_account_prefix = var.service_account_prefix
 
   // Certificate authority
   ca_pool_name = var.ca_pool_name
@@ -331,9 +332,10 @@ module "fulcio" {
 module "timestamp" {
   source = "../timestamp"
 
-  region       = var.region
-  project_id   = var.project_id
-  cluster_name = var.cluster_name
+  region                 = var.region
+  project_id             = var.project_id
+  cluster_name           = var.cluster_name
+  service_account_prefix = var.service_account_prefix
 
   // Disable module entirely if timestamp
   // is disabled

--- a/gcp/modules/sigstore/variables.tf
+++ b/gcp/modules/sigstore/variables.tf
@@ -217,8 +217,8 @@ variable "cluster_name" {
   default     = "sigstore-staging"
 }
 
-variable "gke_service_account_prefix" {
-  description = "The prefix of the name of the GKE service accounts"
+variable "service_account_prefix" {
+  description = "The prefix of the name of GCP service accounts"
   type        = string
   default     = ""
 }

--- a/gcp/modules/timestamp/service_accounts.tf
+++ b/gcp/modules/timestamp/service_accounts.tf
@@ -14,9 +14,14 @@
  * limitations under the License.
  */
 
+locals {
+  // The cluster name may be too long to use as a part of a service account ID, which must be under 30 characters total.
+  service_account_prefix = var.service_account_prefix != "" ? var.service_account_prefix : var.cluster_name
+}
+
 // Create the Timestamp Authority service account
 resource "google_service_account" "timestamp-sa" {
-  account_id   = format("%s-timestamp-sa", var.cluster_name)
+  account_id   = format("%s-timestamp-sa", local.service_account_prefix)
   display_name = "Timestamp Authority Service Account"
   project      = var.project_id
 }

--- a/gcp/modules/timestamp/variables.tf
+++ b/gcp/modules/timestamp/variables.tf
@@ -39,6 +39,12 @@ variable "cluster_name" {
   type        = string
 }
 
+variable "service_account_prefix" {
+  description = "The prefix of the name of the GKE service accounts"
+  type        = string
+  default     = ""
+}
+
 // KMS
 variable "timestamp_keyring_name" {
   type        = string


### PR DESCRIPTION
The cluster name for the new region is too long to use as a part of a service account ID, which must be under 30 characters total. Following the GKE module's example, make the service account prefix for fulcio and timestamp configurable. This also changes the name of the sigstore module service account variable to be reusable for all wrapped modules.

gke-cluster, fulcio, and timestamp should be the only modules affected by the extended name of the new cluster so these are the only modules that have this configurability.

Relates to https://github.com/sigstore/public-good-instance/issues/3603

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
