### PR TITLE
Make project_roles conditional on members list

### DIFF
--- a/gcp/modules/sigstore/sigstore.tf
+++ b/gcp/modules/sigstore/sigstore.tf
@@ -16,6 +16,8 @@
 
 // IAM project roles
 module "project_roles" {
+  count = length(var.iam_members_to_roles) > 0 ? 1 : 0
+
   source               = "../project_roles"
   project_id           = var.project_id
   iam_members_to_roles = var.iam_members_to_roles

--- a/gcp/modules/sigstore_global/global.tf
+++ b/gcp/modules/sigstore_global/global.tf
@@ -15,6 +15,8 @@
  */
 
 module "project_roles" {
+  count = length(var.iam_members_to_roles) > 0 ? 1 : 0
+
   source               = "../project_roles"
   project_id           = var.project_id
   iam_members_to_roles = var.iam_members_to_roles


### PR DESCRIPTION
Management of project_roles is moving from the sigstore module to the sigstore_global module. To avoid deleting and recreating every IAM membership, make the whole module conditional on the list. Then one `moved` resource can be used to redefine the location of the whole module and all the IAM bindings contained within.

Relates to https://github.com/sigstore/public-good-instance/issues/3603

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
