### PR TITLE
Make cluster node pool network tags condition on autoscaling

### DIFF
--- a/gcp/modules/gke_cluster/cluster.tf
+++ b/gcp/modules/gke_cluster/cluster.tf
@@ -74,8 +74,11 @@ resource "google_container_cluster" "cluster" {
   }
 
   node_pool_auto_config {
-    network_tags {
-      tags = [local.cluster_network_tag]
+    dynamic "network_tags" {
+      for_each = var.cluster_autoscaling_enabled ? [1] : []
+      content {
+        tags = [local.cluster_network_tag]
+      }
     }
   }
 


### PR DESCRIPTION
Without this change, deploying a new cluster with
cluster_autoscaling_enabled=false gives this error:

```
node_pool_auto_config network tags can only be set if enable_autopilot or cluster_autoscaling is enabled
```

The node pool network tags are already set in the separate node pool resource, so they do not need to be configured through the cluster and doing so is incompatible with disabling autoscaling.

Fix for https://github.com/sigstore/public-good-instance/actions/runs/27034175221/job/79793841926
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
