### PR TITLE
monitoring: make workloads dashboard plan idempotent

### DIFF
--- a/gcp/modules/monitoring/infra/dashboards.tf
+++ b/gcp/modules/monitoring/infra/dashboards.tf
@@ -17,7 +17,7 @@
 resource "google_monitoring_dashboard" "spanner_cpu_dashboard" {
   dashboard_json = <<EOF
 {
-  "displayName": "Spanner CPU Alerts.",
+  "displayName": "Spanner CPU Alerts",
   "mosaicLayout": {
     "columns": 48,
     "tiles": [

--- a/gcp/modules/monitoring/infra/dashboards.tf
+++ b/gcp/modules/monitoring/infra/dashboards.tf
@@ -17,7 +17,7 @@
 resource "google_monitoring_dashboard" "spanner_cpu_dashboard" {
   dashboard_json = <<EOF
 {
-  "displayName": "Spanner CPU Alerts",
+  "displayName": "Spanner CPU Alerts (plan verification)",
   "mosaicLayout": {
     "columns": 48,
     "tiles": [

--- a/gcp/modules/monitoring/infra/dashboards.tf
+++ b/gcp/modules/monitoring/infra/dashboards.tf
@@ -17,7 +17,7 @@
 resource "google_monitoring_dashboard" "spanner_cpu_dashboard" {
   dashboard_json = <<EOF
 {
-  "displayName": "Spanner CPU Alerts (plan verification)",
+  "displayName": "Spanner CPU Alerts.",
   "mosaicLayout": {
     "columns": 48,
     "tiles": [

--- a/gcp/modules/monitoring/infra/workloads.json
+++ b/gcp/modules/monitoring/infra/workloads.json
@@ -1,5 +1,5 @@
 {
-  "displayName": "Workloads CPU & Memory (plan verification)",
+  "displayName": "Workloads CPU & Memory",
   "mosaicLayout": {
     "columns": 12,
     "tiles": [

--- a/gcp/modules/monitoring/infra/workloads.json
+++ b/gcp/modules/monitoring/infra/workloads.json
@@ -1,5 +1,5 @@
 {
-  "displayName": "Workloads CPU & Memory",
+  "displayName": "Workloads CPU & Memory (plan verification)",
   "mosaicLayout": {
     "columns": 12,
     "tiles": [

--- a/gcp/modules/monitoring/infra/workloads.json
+++ b/gcp/modules/monitoring/infra/workloads.json
@@ -4,8 +4,6 @@
     "columns": 12,
     "tiles": [
       {
-        "xPos": 0,
-        "yPos": 0,
         "width": 12,
         "height": 4,
         "widget": {
@@ -21,7 +19,6 @@
         }
       },
       {
-        "xPos": 0,
         "yPos": 4,
         "width": 6,
         "height": 4,
@@ -95,7 +92,6 @@
         }
       },
       {
-        "xPos": 0,
         "yPos": 8,
         "width": 6,
         "height": 4,
@@ -185,7 +181,6 @@
         }
       },
       {
-        "xPos": 0,
         "yPos": 12,
         "width": 6,
         "height": 4,
@@ -259,7 +254,6 @@
         }
       },
       {
-        "xPos": 0,
         "yPos": 16,
         "width": 6,
         "height": 4,
@@ -336,7 +330,6 @@
         }
       },
       {
-        "xPos": 0,
         "yPos": 20,
         "width": 6,
         "height": 4,
@@ -414,7 +407,6 @@
         }
       },
       {
-        "xPos": 0,
         "yPos": 24,
         "width": 6,
         "height": 4,
@@ -486,7 +478,6 @@
         }
       },
       {
-        "xPos": 0,
         "yPos": 28,
         "width": 12,
         "height": 4,


### PR DESCRIPTION
The GCP Monitoring API strips default-valued fields (`xPos: 0`, `yPos: 0`) from the dashboard JSON it returns, so every subsequent `terraform plan` against `google_monitoring_dashboard.workloads` shows a spurious `+ xPos = 0` / `+ yPos = 0` update.

Example drift from a recent staging apply: https://github.com/sigstore/public-good-instance/actions/runs/27028115518/job/79773220251

Drop the explicit zero defaults from `gcp/modules/monitoring/infra/workloads.json` so the rendered config matches what the API returns. No behavioral change — the resulting dashboard layout is identical.