### PR TITLE
Make service accounts configurable

### DIFF
--- a/gcp/modules/argocd/argocd.tf
+++ b/gcp/modules/argocd/argocd.tf
@@ -134,7 +134,7 @@ resource "helm_release" "argocd_apps" {
 # - Client ID needs to be enabled for domain-wide delegation
 # - SA needs to be granted "Groups Reader" role
 resource "google_service_account" "argocd-directory-api-sa" {
-  account_id   = "argocd-directory-api-sa"
+  account_id   = var.service_account_id
   display_name = "ArgoCD Directory API Service Account"
   project      = var.project_id
 }

--- a/gcp/modules/argocd/variables.tf
+++ b/gcp/modules/argocd/variables.tf
@@ -78,3 +78,9 @@ variable "gcp_secret_name_argocd_oauth_client_secret" {
   description = "GCP Secret name that holds the OAuth client secret used by ArgoCD's Dex instance."
   type        = string
 }
+
+variable "service_account_id" {
+  description = "Name of the Google service account."
+  type        = string
+  default     = "argocd-directory-api-sa"
+}

--- a/gcp/modules/external_secrets/external_secrets.tf
+++ b/gcp/modules/external_secrets/external_secrets.tf
@@ -35,7 +35,7 @@ resource "helm_release" "external_secrets" {
 }
 
 resource "google_service_account" "external_secrets_sa" {
-  account_id   = "external-secrets-sa"
+  account_id   = var.service_account_id
   display_name = "external-secrets Service Account"
   project      = var.project_id
 }

--- a/gcp/modules/external_secrets/variables.tf
+++ b/gcp/modules/external_secrets/variables.tf
@@ -31,3 +31,9 @@ variable "project_id" {
     error_message = "Must specify project_id variable."
   }
 }
+
+variable "service_account_id" {
+  description = "Name of the Google service account."
+  type        = string
+  default     = "external-secrets-sa"
+}


### PR DESCRIPTION
Make the argocd and external_secrets GCP service accounts configurable so that new instantiations for new clusters don't collide.

Relates to https://github.com/sigstore/public-good-instance/issues/3603
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
