### PR TITLE
Disambiguate log-based metric alerts by cluster

### DIFF
--- a/gcp/modules/monitoring/fulcio/fulcio_alerts.tf
+++ b/gcp/modules/monitoring/fulcio/fulcio_alerts.tf
@@ -204,7 +204,7 @@ resource "google_monitoring_alert_policy" "fulcio_k8s_pod_restart_failing_contai
       comparison              = "COMPARISON_GT"
       duration                = "600s"
       evaluation_missing_data = "EVALUATION_MISSING_DATA_INACTIVE"
-      filter                  = "metric.type=\"logging.googleapis.com/user/fulcio/k8s_pod/restarting-failed-container\" resource.type=\"k8s_pod\""
+      filter                  = format("metric.type=\"logging.googleapis.com/user/fulcio/%s/k8s_pod/restarting-failed-container\" resource.type=\"k8s_pod\"", var.cluster_name)
       threshold_value         = "1"
 
       trigger {
@@ -251,7 +251,7 @@ resource "google_monitoring_alert_policy" "fulcio_k8s_pod_unschedulable" {
       comparison              = "COMPARISON_GT"
       duration                = "600s"
       evaluation_missing_data = "EVALUATION_MISSING_DATA_INACTIVE"
-      filter                  = "metric.type=\"logging.googleapis.com/user/fulcio/k8s_pod/unschedulable\" resource.type=\"k8s_pod\""
+      filter                  = format("metric.type=\"logging.googleapis.com/user/fulcio/%s/k8s_pod/unschedulable\" resource.type=\"k8s_pod\"", var.cluster_name)
       threshold_value         = "1"
 
       trigger {

--- a/gcp/modules/monitoring/fulcio/metrics.tf
+++ b/gcp/modules/monitoring/fulcio/metrics.tf
@@ -20,7 +20,7 @@
 resource "google_logging_metric" "fulcio_k8s_pod_restart_failing_container" {
   count       = var.create_logging_metrics ? 1 : 0
   description = "Counts the number of k8s_pod resource logs that contain the \"restarting failed container\" message"
-  filter      = "resource.labels.namespace_name=\"fulcio-system\"\nresource.type=k8s_pod AND severity>=WARNING\n\"Back-off restarting failed container\"\n"
+  filter      = format("resource.labels.namespace_name=\"fulcio-system\"\nresource.labels.cluster_name=\"%s\"\nresource.type=k8s_pod AND severity>=WARNING\n\"Back-off restarting failed container\"\n", var.cluster_name)
 
   metric_descriptor {
     metric_kind = "DELTA"
@@ -28,14 +28,14 @@ resource "google_logging_metric" "fulcio_k8s_pod_restart_failing_container" {
     value_type  = "INT64"
   }
 
-  name    = "fulcio/k8s_pod/restarting-failed-container"
+  name    = format("fulcio/%s/k8s_pod/restarting-failed-container", var.cluster_name)
   project = var.project_id
 }
 
 resource "google_logging_metric" "k8s_pod_unschedulable" {
   count       = var.create_logging_metrics ? 1 : 0
   description = "Counts the number of k8s_pod resource logs that contain the unschedulable message"
-  filter      = "resource.labels.namespace_name=\"fulcio-system\"\nresource.type=k8s_pod AND severity>=WARNING\n\"unschedulable\"\n"
+  filter      = format("resource.labels.namespace_name=\"fulcio-system\"\nresource.labels.cluster_name=\"%s\"\nresource.type=k8s_pod AND severity>=WARNING\n\"unschedulable\"\n", var.cluster_name)
 
   metric_descriptor {
     metric_kind = "DELTA"
@@ -43,6 +43,6 @@ resource "google_logging_metric" "k8s_pod_unschedulable" {
     value_type  = "INT64"
   }
 
-  name    = "fulcio/k8s_pod/unschedulable"
+  name    = format("fulcio/%s/k8s_pod/unschedulable", var.cluster_name)
   project = var.project_id
 }

--- a/gcp/modules/monitoring/timestamp/metrics.tf
+++ b/gcp/modules/monitoring/timestamp/metrics.tf
@@ -19,7 +19,7 @@
 resource "google_logging_metric" "timestamp_k8s_pod_restart_failing_container" {
   count       = var.create_logging_metrics ? 1 : 0
   description = "Counts the number of logs that contain the \"restarting failed container\" message"
-  filter      = "resource.labels.namespace_name=\"tsa-system\"\nresource.type=k8s_pod AND severity>=WARNING\n\"Back-off restarting failed container\"\n"
+  filter      = format("resource.labels.namespace_name=\"tsa-system\"\nresource.labels.cluster_name=\"%s\"\nresource.type=k8s_pod AND severity>=WARNING\n\"Back-off restarting failed container\"\n", var.cluster_name)
 
   metric_descriptor {
     metric_kind = "DELTA"
@@ -27,14 +27,14 @@ resource "google_logging_metric" "timestamp_k8s_pod_restart_failing_container" {
     value_type  = "INT64"
   }
 
-  name    = "timestamp/k8s_pod/restarting-failed-container"
+  name    = format("timestamp/%s/k8s_pod/restarting-failed-container", var.cluster_name)
   project = var.project_id
 }
 
 resource "google_logging_metric" "k8s_pod_unschedulable" {
   count       = var.create_logging_metrics ? 1 : 0
   description = "Counts the number of k8s_pod resource logs that contain the message \"unschedulable\""
-  filter      = "resource.labels.namespace_name=\"tsa-system\"\nresource.type=k8s_pod AND severity>=WARNING\n\"unschedulable\"\n"
+  filter      = format("resource.labels.namespace_name=\"tsa-system\"\nresource.labels.cluster_name=\"%s\"\nresource.type=k8s_pod AND severity>=WARNING\n\"unschedulable\"\n", var.cluster_name)
 
   metric_descriptor {
     metric_kind = "DELTA"
@@ -42,6 +42,6 @@ resource "google_logging_metric" "k8s_pod_unschedulable" {
     value_type  = "INT64"
   }
 
-  name    = "timestamp/k8s_pod/unschedulable"
+  name    = format("timestamp/k8s_pod/unschedulable", var.cluster_name)
   project = var.project_id
 }

--- a/gcp/modules/monitoring/timestamp/timestamp_alerts.tf
+++ b/gcp/modules/monitoring/timestamp/timestamp_alerts.tf
@@ -76,7 +76,7 @@ resource "google_monitoring_alert_policy" "timestamp_k8s_pod_restart_failing_con
       comparison              = "COMPARISON_GT"
       duration                = "600s"
       evaluation_missing_data = "EVALUATION_MISSING_DATA_INACTIVE"
-      filter                  = "metric.type=\"logging.googleapis.com/user/timestamp/k8s_pod/restarting-failed-container\" resource.type=\"k8s_pod\""
+      filter                  = format("metric.type=\"logging.googleapis.com/user/timestamp/%s/k8s_pod/restarting-failed-container\" resource.type=\"k8s_pod\"", var.cluster_name)
       threshold_value         = "1"
 
       trigger {
@@ -121,7 +121,7 @@ resource "google_monitoring_alert_policy" "timestamp_k8s_pod_unschedulable" {
 
       comparison      = "COMPARISON_GT"
       duration        = "600s"
-      filter          = "metric.type=\"logging.googleapis.com/user/timestamp/k8s_pod/unschedulable\" resource.type=\"k8s_pod\""
+      filter          = format("metric.type=\"logging.googleapis.com/user/timestamp/%s/k8s_pod/unschedulable\" resource.type=\"k8s_pod\"", var.cluster_name)
       threshold_value = "1"
 
       trigger {


### PR DESCRIPTION
Since there is now >=1 cluster per environment, alerts triggered by one need to be easily distinguished from the other.

Relates to https://github.com/sigstore/public-good-instance/issues/3603
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
