### PR TITLE
More monitoring disambiguation

### DIFF
--- a/gcp/modules/monitoring/fulcio/slo.tf
+++ b/gcp/modules/monitoring/fulcio/slo.tf
@@ -20,15 +20,15 @@ module "slos" {
 
   project_id            = var.project_id
   project_number        = var.project_number
-  service_id            = "fulcio"
-  display_name          = "Fulcio"
+  service_id            = format("fulcio-%s", var.cluster_location)
+  display_name          = format("Fulcio (%s)", var.cluster_location)
   resource_name         = format("//container.googleapis.com/projects/%s/locations/%s/clusters/%s/k8s/namespaces/%s", var.project_id, var.cluster_location, var.cluster_name, var.gke_namespace)
   notification_channels = local.notification_channels
 
   availability_slos = {
     server-availability = {
       display_prefix            = "Availability (Server)"
-      base_total_service_filter = format("metric.type=\"prometheus.googleapis.com/grpc_server_handled_total/counter\" resource.type=\"prometheus_target\" resource.labels.namespace=\"%s\"", var.gke_namespace)
+      base_total_service_filter = format("metric.type=\"prometheus.googleapis.com/grpc_server_handled_total/counter\" resource.type=\"prometheus_target\" resource.labels.namespace=\"%s\" resource.labels.location=\"%s\"", var.gke_namespace, var.cluster_location)
       # Only count server errors.
       # TODO: If clients can trigger DeadlineExceeded with short deadlines, reconsider this metric.
       bad_filter = "metric.labels.grpc_method=one_of(\"DeadlineExceeded\",\"Internal\")"
@@ -68,7 +68,7 @@ module "slos" {
     },
     prober-availability = {
       display_prefix            = "Availability (Prober)"
-      base_total_service_filter = format("metric.type=\"prometheus.googleapis.com/api_endpoint_latency_count/summary\" resource.type=\"prometheus_target\" metric.labels.host=\"%s\"", var.prober_url)
+      base_total_service_filter = format("metric.type=\"prometheus.googleapis.com/api_endpoint_latency_count/summary\" resource.type=\"prometheus_target\" metric.labels.host=\"%s\" resource.labels.location=\"%s\"", var.prober_url, var.cluster_location)
       bad_filter                = "metric.labels.status_code!=monitoring.regex.full_match(\"20[0-1]\")"
       slos = {
         all-methods = {

--- a/gcp/modules/monitoring/timestamp/slo.tf
+++ b/gcp/modules/monitoring/timestamp/slo.tf
@@ -20,15 +20,15 @@ module "slos" {
 
   project_id            = var.project_id
   project_number        = var.project_number
-  service_id            = "timestamp"
-  display_name          = "Timestamp Authority"
+  service_id            = format("timestamp-%s", var.cluster_location)
+  display_name          = format("Timestamp Authority (%s)", var.cluster_location)
   resource_name         = format("//container.googleapis.com/projects/%s/locations/%s/clusters/%s/k8s/namespaces/%s", var.project_id, var.cluster_location, var.cluster_name, var.gke_namespace)
   notification_channels = local.notification_channels
 
   availability_slos = {
     server-availability = {
       display_prefix            = "Availability (Server)"
-      base_total_service_filter = "metric.type=\"prometheus.googleapis.com/timestamp_authority_http_requests_total/counter\" resource.type=\"prometheus_target\""
+      base_total_service_filter = format("metric.type=\"prometheus.googleapis.com/timestamp_authority_http_requests_total/counter\" resource.type=\"prometheus_target\" resource.labels.location=\"%s\"", var.cluster_location)
       # Only count 500s as server errors since clients can trigger 400s.
       bad_filter = "metric.labels.code=monitoring.regex.full_match(\"5[0-9][0-9]\")"
       slos = {


### PR DESCRIPTION
Without this change, terraform apply fails because the identifiers of the SLO services for fulcio and TSA for the new region are the same as the existing ones. This change includes the region in the naming so that each is unique, and also updates the metrics filters for the SLOs so that they are each only picking up alerts from one cluster or the other.

Relates to https://github.com/sigstore/public-good-instance/issues/3603
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
