### PR TITLE
Remove unused Fulcio alert

### DIFF
--- a/gcp/modules/monitoring/fulcio/fulcio_alerts.tf
+++ b/gcp/modules/monitoring/fulcio/fulcio_alerts.tf
@@ -140,46 +140,6 @@ resource "google_monitoring_alert_policy" "ca_service_cert_expiration_alert" {
   project               = var.project_id
 }
 
-resource "google_monitoring_alert_policy" "ca_service_cert_quota" {
-  alert_strategy {
-    auto_close = "604800s"
-  }
-
-  combiner = "OR"
-
-  conditions {
-    condition_threshold {
-      aggregations {
-        alignment_period   = "300s"
-        per_series_aligner = "ALIGN_RATE"
-      }
-
-      comparison      = "COMPARISON_GT"
-      duration        = "300s"
-      filter          = format("metric.type=\"privateca.googleapis.com/ca/cert/create_count\" resource.type=\"privateca.googleapis.com/CertificateAuthority\" resource.label.\"ca_pool_id\"=\"%s\"", var.ca_pool_name)
-      threshold_value = "25"
-
-      trigger {
-        count   = "1"
-        percent = "0"
-      }
-    }
-
-    display_name = "Certificate creation count for sigstore [RATE]"
-  }
-
-  display_name = "Certificate creation count for sigstore CA above quota"
-
-  documentation {
-    content   = "According to docs for the CA service, the DevOps tier CA has a [request quota](https://cloud.google.com/certificate-authority-service/quotas#request_quotas) of 25 certs/second.\n;\nThis alert will fire if we exceed 25 certs/second for longer than 5 minutes.\n\nIf this happens, consider increasing quotas as described [here](https://cloud.google.com/docs/quota#requesting_higher_quota)"
-    mime_type = "text/markdown"
-  }
-
-  enabled               = "true"
-  notification_channels = local.notification_channels
-  project               = var.project_id
-}
-
 ### K8s Alerts
 
 resource "google_monitoring_alert_policy" "fulcio_k8s_pod_restart_failing_container" {


### PR DESCRIPTION
Remove the alert policy for the
privateca.googleapis.com/ca/cert/create_count metric. There is no data for this metric in either the staging or production environments because the Fulcio CA pools are not issuing certificates directly, Fulcio itself is. This alert is not needed and can be safely removed.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
