### PR TITLE
Add missing Rekor v2 uptime check

### DIFF
--- a/gcp/modules/monitoring/rekorv2/active_shard/rekorv2_alerts.tf
+++ b/gcp/modules/monitoring/rekorv2/active_shard/rekorv2_alerts.tf
@@ -106,3 +106,40 @@ resource "google_monitoring_alert_policy" "rekorv2_k8s_pod_unschedulable" {
   notification_channels = local.notification_channels
   project               = var.project_id
 }
+
+resource "google_monitoring_alert_policy" "rekorv2_uptime_alert" {
+  # In the absence of data, incident will auto-close in 7 days
+  alert_strategy {
+    auto_close = "604800s"
+  }
+  combiner = "OR"
+
+  conditions {
+    condition_threshold {
+      aggregations {
+        alignment_period     = "60s"
+        cross_series_reducer = "REDUCE_COUNT_FALSE"
+        group_by_fields      = ["resource.*"]
+        per_series_aligner   = "ALIGN_NEXT_OLDER"
+      }
+
+      comparison      = "COMPARISON_GT"
+      duration        = "300s"
+      filter          = format("metric.type=\"monitoring.googleapis.com/uptime_check/check_passed\" resource.type=\"uptime_url\" metric.label.\"check_id\"=\"%s\"", google_monitoring_uptime_check_config.uptime_rekorv2.uptime_check_id)
+      threshold_value = "1"
+
+      trigger {
+        count   = "1"
+        percent = "0"
+      }
+    }
+
+    display_name = "Failure of uptime check_id rekorv2-uptime"
+  }
+
+  display_name          = "Rekor v2 Uptime Alert - ${var.cluster_location}"
+  enabled               = "true"
+  notification_channels = local.notification_channels
+  project               = var.project_id
+  depends_on            = [google_monitoring_uptime_check_config.uptime_rekorv2]
+}

--- a/gcp/modules/monitoring/rekorv2/active_shard/uptime.tf
+++ b/gcp/modules/monitoring/rekorv2/active_shard/uptime.tf
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2026 The Sigstore Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+resource "google_monitoring_uptime_check_config" "uptime_rekorv2" {
+  display_name = "Rekor v2 Uptime - ${var.cluster_location}"
+
+  http_check {
+    mask_headers   = "false"
+    path           = "/healthz"
+    port           = "443"
+    request_method = "GET"
+    use_ssl        = "true"
+    validate_ssl   = "true"
+  }
+
+  monitored_resource {
+    labels = {
+      host       = var.rekor_url
+      project_id = var.project_id
+    }
+  }
+
+  period  = var.uptime_check_period
+  project = var.project_id
+  timeout = "10s"
+}

--- a/gcp/modules/monitoring/rekorv2/active_shard/variables.tf
+++ b/gcp/modules/monitoring/rekorv2/active_shard/variables.tf
@@ -84,3 +84,14 @@ variable "create_slos" {
   type        = bool
   default     = false
 }
+
+variable "rekor_url" {
+  description = "Rekor v2 URL"
+  type        = string
+}
+
+variable "uptime_check_period" {
+  description = "Uptime check period"
+  type        = string
+  default     = "60s"
+}


### PR DESCRIPTION
This check was missing because there may not have been a /healthz endpoint to GET at the time this was implemented. This change adds a new required variable to the rekorv2 monitoring module.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
