### PR TITLE
Add global monitoring uptime resources

### DIFF
--- a/gcp/modules/monitoring/fulcio/fulcio_alerts.tf
+++ b/gcp/modules/monitoring/fulcio/fulcio_alerts.tf
@@ -14,42 +14,9 @@
  * limitations under the License.
  */
 
-// Alert if we see a failure every minute for 5 consecutive minutes
-resource "google_monitoring_alert_policy" "fulcio_uptime_alert" {
-  # In the absence of data, incident will auto-close in 7 days
-  alert_strategy {
-    auto_close = "604800s"
-  }
-  combiner = "OR"
-
-  conditions {
-    condition_threshold {
-      aggregations {
-        alignment_period     = "60s"
-        cross_series_reducer = "REDUCE_COUNT_FALSE"
-        group_by_fields      = ["resource.*"]
-        per_series_aligner   = "ALIGN_NEXT_OLDER"
-      }
-
-      comparison      = "COMPARISON_GT"
-      duration        = "300s"
-      filter          = format("metric.type=\"monitoring.googleapis.com/uptime_check/check_passed\" resource.type=\"uptime_url\" metric.label.\"check_id\"=\"%s\"", google_monitoring_uptime_check_config.uptime_fulcio.uptime_check_id)
-      threshold_value = "1"
-
-      trigger {
-        count   = "1"
-        percent = "0"
-      }
-    }
-
-    display_name = "Failure of uptime check_id fulcio-uptime"
-  }
-
-  display_name          = "Fulcio uptime alert"
-  enabled               = "true"
-  notification_channels = local.notification_channels
-  project               = var.project_id
-  depends_on            = [google_monitoring_uptime_check_config.uptime_fulcio]
+moved {
+  from = google_monitoring_alert_policy.fulcio_uptime_alert
+  to   = module.monitoring_fulcio_global[0].google_monitoring_alert_policy.fulcio_uptime_alert
 }
 
 // Alert if we see a failure every minute for 5 consecutive minutes
@@ -88,7 +55,7 @@ resource "google_monitoring_alert_policy" "ctlog_uptime_alert" {
   enabled               = "true"
   notification_channels = local.notification_channels
   project               = var.project_id
-  depends_on            = [google_monitoring_uptime_check_config.uptime_fulcio]
+  depends_on            = [google_monitoring_uptime_check_config.uptime_ct_log]
 }
 
 ### Certificate Authority Alerts

--- a/gcp/modules/monitoring/fulcio/global/uptime.tf
+++ b/gcp/modules/monitoring/fulcio/global/uptime.tf
@@ -1,0 +1,79 @@
+/**
+ * Copyright 2026 The Sigstore Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+resource "google_monitoring_uptime_check_config" "fulcio_uptime" {
+  display_name = "Fulcio Uptime"
+
+  http_check {
+    mask_headers   = "false"
+    path           = "/api/v1/rootCert"
+    port           = "443"
+    request_method = "GET"
+    use_ssl        = "true"
+    validate_ssl   = "true"
+  }
+
+  monitored_resource {
+    labels = {
+      host       = var.fulcio_url
+      project_id = var.project_id
+    }
+
+    type = "uptime_url"
+  }
+
+  period  = var.uptime_check_period
+  project = var.project_id
+  timeout = "10s"
+}
+
+// Alert if we see a failure every minute for 5 consecutive minutes
+resource "google_monitoring_alert_policy" "fulcio_uptime_alert" {
+  # In the absence of data, incident will auto-close in 7 days
+  alert_strategy {
+    auto_close = "604800s"
+  }
+  combiner = "OR"
+
+  conditions {
+    condition_threshold {
+      aggregations {
+        alignment_period     = "60s"
+        cross_series_reducer = "REDUCE_COUNT_FALSE"
+        group_by_fields      = ["resource.*"]
+        per_series_aligner   = "ALIGN_NEXT_OLDER"
+      }
+
+      comparison      = "COMPARISON_GT"
+      duration        = "300s"
+      filter          = format("metric.type=\"monitoring.googleapis.com/uptime_check/check_passed\" resource.type=\"uptime_url\" metric.label.\"check_id\"=\"%s\"", google_monitoring_uptime_check_config.fulcio_uptime.uptime_check_id)
+      threshold_value = "1"
+
+      trigger {
+        count   = "1"
+        percent = "0"
+      }
+    }
+
+    display_name = "Failure of uptime check_id fulcio-uptime"
+  }
+
+  display_name          = "Fulcio uptime alert"
+  enabled               = "true"
+  notification_channels = local.notification_channels
+  project               = var.project_id
+  depends_on            = [google_monitoring_uptime_check_config.fulcio_uptime]
+}

--- a/gcp/modules/monitoring/fulcio/global/variables.tf
+++ b/gcp/modules/monitoring/fulcio/global/variables.tf
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2026 The Sigstore Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "project_id" {
+  type    = string
+  default = ""
+  validation {
+    condition     = length(var.project_id) > 0
+    error_message = "Must specify PROJECT_ID variable."
+  }
+}
+
+// URLs for Sigstore services
+variable "fulcio_url" {
+  description = "Fulcio URL"
+  type        = string
+  default     = "fulcio.sigstore.dev"
+}
+
+variable "uptime_check_period" {
+  type    = string
+  default = "60s"
+}
+
+// Set-up for notification channel for alerting
+variable "notification_channel_ids" {
+  description = "List of notification channel IDs which alerts should be sent to. You can find this by running `gcloud alpha monitoring channels list`."
+  type        = list(string)
+  default     = []
+}
+
+locals {
+  notification_channels = toset([for nc in var.notification_channel_ids : format("projects/%v/notificationChannels/%v", var.project_id, nc)])
+}

--- a/gcp/modules/monitoring/fulcio/global/versions.tf
+++ b/gcp/modules/monitoring/fulcio/global/versions.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2025 The Sigstore Authors
+ * Copyright 2026 The Sigstore Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,17 +14,13 @@
  * limitations under the License.
  */
 
-module "monitoring_timestamp_global" {
-  count = var.check_uptime ? 1 : 0
+terraform {
+  required_version = "1.14.2"
 
-  source = "./global"
-
-  project_id          = var.project_id
-  timestamp_url       = var.timestamp_url
-  uptime_check_period = var.uptime_check_period
-}
-
-moved {
-  from = google_monitoring_uptime_check_config.uptime_timestamp
-  to   = module.monitoring_timestamp_global[0].google_monitoring_uptime_check_config.uptime_timestamp
+  required_providers {
+    google = {
+      version = "7.21.0"
+      source  = "hashicorp/google"
+    }
+  }
 }

--- a/gcp/modules/monitoring/fulcio/uptime.tf
+++ b/gcp/modules/monitoring/fulcio/uptime.tf
@@ -14,30 +14,19 @@
  * limitations under the License.
  */
 
-resource "google_monitoring_uptime_check_config" "uptime_fulcio" {
-  display_name = "Fulcio Uptime"
+module "monitoring_fulcio_global" {
+  count = var.check_uptime ? 1 : 0
 
-  http_check {
-    mask_headers   = "false"
-    path           = "/api/v1/rootCert"
-    port           = "443"
-    request_method = "GET"
-    use_ssl        = "true"
-    validate_ssl   = "true"
-  }
+  source = "./global"
 
-  monitored_resource {
-    labels = {
-      host       = var.fulcio_url
-      project_id = var.project_id
-    }
+  project_id          = var.project_id
+  fulcio_url          = var.fulcio_url
+  uptime_check_period = var.uptime_check_period
+}
 
-    type = "uptime_url"
-  }
-
-  period  = var.uptime_check_period
-  project = var.project_id
-  timeout = "10s"
+moved {
+  from = google_monitoring_uptime_check_config.uptime_fulcio
+  to   = module.monitoring_fulcio_global[0].google_monitoring_uptime_check_config.fulcio_uptime
 }
 
 resource "google_monitoring_uptime_check_config" "uptime_ct_log" {

--- a/gcp/modules/monitoring/fulcio/variables.tf
+++ b/gcp/modules/monitoring/fulcio/variables.tf
@@ -117,3 +117,9 @@ variable "create_logging_metrics" {
   type        = bool
   default     = true
 }
+
+variable "check_uptime" {
+  description = "Whether to manage the uptime check from this module. Disable it to manage global uptime checks from the global monitoring module."
+  type        = bool
+  default     = true
+}

--- a/gcp/modules/monitoring/rekorv2/lb/alerts.tf
+++ b/gcp/modules/monitoring/rekorv2/lb/alerts.tf
@@ -1,0 +1,52 @@
+/**
+ * Copyright 2026 The Sigstore Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+resource "google_monitoring_alert_policy" "rekor_v2_global_uptime_alert" {
+  # In the absence of data, incident will auto-close in 7 days
+  alert_strategy {
+    auto_close = "604800s"
+  }
+  combiner = "OR"
+
+  conditions {
+    condition_threshold {
+      aggregations {
+        alignment_period     = "60s"
+        cross_series_reducer = "REDUCE_COUNT_FALSE"
+        group_by_fields      = ["resource.*"]
+        per_series_aligner   = "ALIGN_NEXT_OLDER"
+      }
+
+      comparison      = "COMPARISON_GT"
+      duration        = "300s"
+      filter          = format("metric.type=\"monitoring.googleapis.com/uptime_check/check_passed\" resource.type=\"uptime_url\" metric.label.\"check_id\"=\"%s\"", google_monitoring_uptime_check_config.rekor_v2_global_uptime.uptime_check_id)
+      threshold_value = "1"
+
+      trigger {
+        count   = "1"
+        percent = "0"
+      }
+    }
+
+    display_name = "Failure of uptime check_id rekor-v2-global-uptime"
+  }
+
+  display_name          = "Rekor v2 Uptime Alert - global"
+  enabled               = "true"
+  notification_channels = local.notification_channels
+  project               = var.project_id
+  depends_on            = [google_monitoring_uptime_check_config.rekor_v2_global_uptime]
+}

--- a/gcp/modules/monitoring/rekorv2/lb/uptime.tf
+++ b/gcp/modules/monitoring/rekorv2/lb/uptime.tf
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2026 The Sigstore Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+resource "google_monitoring_uptime_check_config" "rekor_v2_global_uptime" {
+  display_name = "Rekor v2 Uptime - global"
+
+  http_check {
+    mask_headers   = "false"
+    path           = "/healthz"
+    port           = "443"
+    request_method = "GET"
+    use_ssl        = "true"
+    validate_ssl   = "true"
+  }
+
+  monitored_resource {
+    labels = {
+      host       = var.rekor_global_url
+      project_id = var.project_id
+    }
+
+    type = "uptime_url"
+  }
+
+  period  = var.uptime_check_period
+  project = var.project_id
+  timeout = "10s"
+}

--- a/gcp/modules/monitoring/rekorv2/lb/variables.tf
+++ b/gcp/modules/monitoring/rekorv2/lb/variables.tf
@@ -57,3 +57,14 @@ variable "create_slos" {
   type        = bool
   default     = false
 }
+
+variable "rekor_global_url" {
+  description = "Rekor v2 global URL"
+  type        = string
+}
+
+variable "uptime_check_period" {
+  description = "Uptime check period"
+  type        = string
+  default     = "60s"
+}

--- a/gcp/modules/monitoring/sigstore.tf
+++ b/gcp/modules/monitoring/sigstore.tf
@@ -66,6 +66,7 @@ module "fulcio" {
   prober_url               = var.prober_fulcio_url
   create_slos              = var.create_slos
   uptime_check_period      = var.uptime_check_period
+  check_uptime             = var.fulcio_check_uptime
   create_logging_metrics   = var.fulcio_create_logging_metrics
 
   depends_on = [
@@ -88,6 +89,7 @@ module "timestamp" {
   prober_url               = var.prober_timestamp_url
   create_slos              = var.create_slos
   uptime_check_period      = var.uptime_check_period
+  check_uptime             = var.timestamp_check_uptime
   create_logging_metrics   = var.timestamp_create_logging_metrics
 
   depends_on = [

--- a/gcp/modules/monitoring/tesseract/lb/alerts.tf
+++ b/gcp/modules/monitoring/tesseract/lb/alerts.tf
@@ -1,0 +1,52 @@
+/**
+ * Copyright 2026 The Sigstore Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+resource "google_monitoring_alert_policy" "ctlog_global_uptime_alert" {
+  # In the absence of data, incident will auto-close in 7 days
+  alert_strategy {
+    auto_close = "604800s"
+  }
+  combiner = "OR"
+
+  conditions {
+    condition_threshold {
+      aggregations {
+        alignment_period     = "60s"
+        cross_series_reducer = "REDUCE_COUNT_FALSE"
+        group_by_fields      = ["resource.*"]
+        per_series_aligner   = "ALIGN_NEXT_OLDER"
+      }
+
+      comparison      = "COMPARISON_GT"
+      duration        = "300s"
+      filter          = format("metric.type=\"monitoring.googleapis.com/uptime_check/check_passed\" resource.type=\"uptime_url\" metric.label.\"check_id\"=\"%s\"", google_monitoring_uptime_check_config.ctlog_global_uptime.uptime_check_id)
+      threshold_value = "1"
+
+      trigger {
+        count   = "1"
+        percent = "0"
+      }
+    }
+
+    display_name = "Failure of uptime check_id ctlog-global-uptime"
+  }
+
+  display_name          = "CT Log (TesseraCT) Uptime Alert - global"
+  enabled               = "true"
+  notification_channels = local.notification_channels
+  project               = var.project_id
+  depends_on            = [google_monitoring_uptime_check_config.ctlog_global_uptime]
+}

--- a/gcp/modules/monitoring/tesseract/lb/uptime.tf
+++ b/gcp/modules/monitoring/tesseract/lb/uptime.tf
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2026 The Sigstore Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+resource "google_monitoring_uptime_check_config" "ctlog_global_uptime" {
+  display_name = "CT Log Uptime - global"
+
+  http_check {
+    mask_headers   = "false"
+    path           = "/ct/v1/get-roots"
+    port           = "443"
+    request_method = "GET"
+    use_ssl        = "true"
+    validate_ssl   = "true"
+  }
+
+  monitored_resource {
+    labels = {
+      host       = var.ctlog_global_url
+      project_id = var.project_id
+    }
+
+    type = "uptime_url"
+  }
+
+  period  = var.uptime_check_period
+  project = var.project_id
+  timeout = "10s"
+}

--- a/gcp/modules/monitoring/tesseract/lb/variables.tf
+++ b/gcp/modules/monitoring/tesseract/lb/variables.tf
@@ -58,3 +58,14 @@ variable "create_slos" {
   type        = bool
   default     = false
 }
+
+variable "ctlog_global_url" {
+  description = "CT log global URL"
+  type        = string
+}
+
+variable "uptime_check_period" {
+  description = "Uptime check period"
+  type        = string
+  default     = "60s"
+}

--- a/gcp/modules/monitoring/timestamp/global/uptime.tf
+++ b/gcp/modules/monitoring/timestamp/global/uptime.tf
@@ -1,0 +1,79 @@
+/**
+ * Copyright 2026 The Sigstore Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+resource "google_monitoring_uptime_check_config" "timestamp_uptime" {
+  display_name = "Timestamp Authority Uptime"
+
+  http_check {
+    mask_headers   = "false"
+    path           = "/api/v1/timestamp/certchain"
+    port           = "443"
+    request_method = "GET"
+    use_ssl        = "true"
+    validate_ssl   = "true"
+  }
+
+  monitored_resource {
+    labels = {
+      host       = var.timestamp_url
+      project_id = var.project_id
+    }
+
+    type = "uptime_url"
+  }
+
+  period  = var.uptime_check_period
+  project = var.project_id
+  timeout = "10s"
+}
+
+// Alert if we see a failure every minute for 5 consecutive minutes
+resource "google_monitoring_alert_policy" "timestamp_uptime_alerts" {
+  # In the absence of data, incident will auto-close in 7 days
+  alert_strategy {
+    auto_close = "604800s"
+  }
+  combiner = "OR"
+
+  conditions {
+    condition_threshold {
+      aggregations {
+        alignment_period     = "60s"
+        cross_series_reducer = "REDUCE_COUNT_FALSE"
+        group_by_fields      = ["resource.*"]
+        per_series_aligner   = "ALIGN_NEXT_OLDER"
+      }
+
+      comparison      = "COMPARISON_GT"
+      duration        = "300s"
+      filter          = format("metric.type=\"monitoring.googleapis.com/uptime_check/check_passed\" resource.type=\"uptime_url\" metric.label.\"check_id\"=\"%s\"", google_monitoring_uptime_check_config.timestamp_uptime.uptime_check_id)
+      threshold_value = "1"
+
+      trigger {
+        count   = "1"
+        percent = "0"
+      }
+    }
+
+    display_name = "Failure of uptime check_id timestamp-uptime"
+  }
+
+  display_name          = "Timestamp Authority uptime alert"
+  enabled               = "true"
+  notification_channels = local.notification_channels
+  project               = var.project_id
+  depends_on            = [google_monitoring_uptime_check_config.timestamp_uptime]
+}

--- a/gcp/modules/monitoring/timestamp/global/variables.tf
+++ b/gcp/modules/monitoring/timestamp/global/variables.tf
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2026 The Sigstore Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "project_id" {
+  type    = string
+  default = ""
+  validation {
+    condition     = length(var.project_id) > 0
+    error_message = "Must specify PROJECT_ID variable."
+  }
+}
+
+variable "uptime_check_period" {
+  type    = string
+  default = "60s"
+}
+
+// URLs for Sigstore services
+variable "timestamp_url" {
+  description = "Timestamp Authority URL"
+  type        = string
+  default     = "timestamp.sigstore.dev"
+}
+
+// Set-up for notification channel for alerting
+variable "notification_channel_ids" {
+  description = "List of notification channel IDs which alerts should be sent to. You can find this by running `gcloud alpha monitoring channels list`."
+  type        = list(string)
+  default     = []
+}
+
+locals {
+  notification_channels = toset([for nc in var.notification_channel_ids : format("projects/%v/notificationChannels/%v", var.project_id, nc)])
+}

--- a/gcp/modules/monitoring/timestamp/global/versions.tf
+++ b/gcp/modules/monitoring/timestamp/global/versions.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2025 The Sigstore Authors
+ * Copyright 2026 The Sigstore Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,17 +14,13 @@
  * limitations under the License.
  */
 
-module "monitoring_timestamp_global" {
-  count = var.check_uptime ? 1 : 0
+terraform {
+  required_version = "1.14.2"
 
-  source = "./global"
-
-  project_id          = var.project_id
-  timestamp_url       = var.timestamp_url
-  uptime_check_period = var.uptime_check_period
-}
-
-moved {
-  from = google_monitoring_uptime_check_config.uptime_timestamp
-  to   = module.monitoring_timestamp_global[0].google_monitoring_uptime_check_config.uptime_timestamp
+  required_providers {
+    google = {
+      version = "7.21.0"
+      source  = "hashicorp/google"
+    }
+  }
 }

--- a/gcp/modules/monitoring/timestamp/timestamp_alerts.tf
+++ b/gcp/modules/monitoring/timestamp/timestamp_alerts.tf
@@ -14,42 +14,9 @@
  * limitations under the License.
  */
 
-// Alert if we see a failure every minute for 5 consecutive minutes
-resource "google_monitoring_alert_policy" "timestamp_uptime_alerts" {
-  # In the absence of data, incident will auto-close in 7 days
-  alert_strategy {
-    auto_close = "604800s"
-  }
-  combiner = "OR"
-
-  conditions {
-    condition_threshold {
-      aggregations {
-        alignment_period     = "60s"
-        cross_series_reducer = "REDUCE_COUNT_FALSE"
-        group_by_fields      = ["resource.*"]
-        per_series_aligner   = "ALIGN_NEXT_OLDER"
-      }
-
-      comparison      = "COMPARISON_GT"
-      duration        = "300s"
-      filter          = format("metric.type=\"monitoring.googleapis.com/uptime_check/check_passed\" resource.type=\"uptime_url\" metric.label.\"check_id\"=\"%s\"", google_monitoring_uptime_check_config.uptime_timestamp.uptime_check_id)
-      threshold_value = "1"
-
-      trigger {
-        count   = "1"
-        percent = "0"
-      }
-    }
-
-    display_name = "Failure of uptime check_id timestamp-uptime"
-  }
-
-  display_name          = "Timestamp Authority uptime alert"
-  enabled               = "true"
-  notification_channels = local.notification_channels
-  project               = var.project_id
-  depends_on            = [google_monitoring_uptime_check_config.uptime_timestamp]
+moved {
+  from = google_monitoring_alert_policy.timestamp_uptime_alerts
+  to   = module.monitoring_timestamp_global[0].google_monitoring_alert_policy.timestamp_uptime_alerts
 }
 
 ### K8s Alerts

--- a/gcp/modules/monitoring/timestamp/variables.tf
+++ b/gcp/modules/monitoring/timestamp/variables.tf
@@ -85,6 +85,12 @@ variable "uptime_check_period" {
   default = "60s"
 }
 
+variable "check_uptime" {
+  description = "Whether to manage the uptime check from this module. Disable it to manage global uptime checks from the global monitoring module."
+  type        = bool
+  default     = true
+}
+
 variable "create_logging_metrics" {
   description = "Whether to create logging metrics. Another instance of the monitoring module may already be managing logging metrics for this service."
   type        = bool

--- a/gcp/modules/monitoring/variables.tf
+++ b/gcp/modules/monitoring/variables.tf
@@ -159,6 +159,18 @@ variable "uptime_check_period" {
   default     = "60s"
 }
 
+variable "fulcio_check_uptime" {
+  description = "Whether to manage the fulcio uptime check from this module. Disable it to manage global uptime checks from the global monitoring module."
+  type        = bool
+  default     = true
+}
+
+variable "timestamp_check_uptime" {
+  description = "Whether to manage the timestamp uptime check from this module. Disable it to manage global uptime checks from the global monitoring module."
+  type        = bool
+  default     = true
+}
+
 variable "cloudsql_enabled" {
   description = "Enable cloudsql monitoring"
   type        = bool

--- a/gcp/modules/sigstore/sigstore.tf
+++ b/gcp/modules/sigstore/sigstore.tf
@@ -119,6 +119,8 @@ module "monitoring" {
   dex_enabled                      = var.monitoring.dex_enabled
   enable_k8s_cpu_utilization_alert = var.enable_k8s_cpu_utilization_alert
   uptime_check_period              = var.monitoring.uptime_check_period
+  fulcio_check_uptime              = var.monitoring.fulcio_check_uptime
+  timestamp_check_uptime           = var.monitoring.timestamp_check_uptime
   cloudsql_enabled                 = var.monitoring.cloudsql_enabled
   tuf_enabled                      = var.monitoring.tuf_enabled
   fulcio_create_logging_metrics    = var.monitoring.fulcio_create_logging_metrics

--- a/gcp/modules/sigstore/variables.tf
+++ b/gcp/modules/sigstore/variables.tf
@@ -174,6 +174,8 @@ variable "monitoring" {
     rekor_enabled                    = optional(bool, true)
     dex_enabled                      = optional(bool, true)
     uptime_check_period              = optional(string, "60s")
+    fulcio_check_uptime              = optional(bool, true)
+    timestamp_check_uptime           = optional(bool, true)
     cloudsql_enabled                 = optional(bool, true)
     tuf_enabled                      = optional(bool, true)
     fulcio_create_logging_metrics    = optional(bool, true)
@@ -193,6 +195,8 @@ variable "monitoring" {
     rekor_enabled                    = true
     dex_enabled                      = true
     uptime_check_period              = "60s"
+    fulcio_check_uptime              = true
+    timestamp_check_uptime           = true
     cloudsql_enabled                 = true
     tuf_enabled                      = true
     fulcio_create_logging_metrics    = true

--- a/gcp/modules/sigstore_global/global.tf
+++ b/gcp/modules/sigstore_global/global.tf
@@ -92,3 +92,21 @@ module "fulcio" {
   enable_healthcheck_logging     = var.enable_loadbalancer_logging
   enable_backend_service_logging = var.enable_loadbalancer_logging
 }
+
+module "fulcio_monitoring" {
+  source = "../monitoring/fulcio/global"
+
+  project_id               = var.project_id
+  fulcio_url               = var.fulcio_url
+  uptime_check_period      = var.fulcio_uptime_check_period
+  notification_channel_ids = var.notification_channel_ids
+}
+
+module "timestamp_monitoring" {
+  source = "../monitoring/timestamp/global"
+
+  project_id               = var.project_id
+  timestamp_url            = var.timestamp_url
+  uptime_check_period      = var.timestamp_uptime_check_period
+  notification_channel_ids = var.notification_channel_ids
+}

--- a/gcp/modules/sigstore_global/variables.tf
+++ b/gcp/modules/sigstore_global/variables.tf
@@ -186,3 +186,31 @@ variable "fulcio_manage_dns_a_record" {
   type        = bool
   default     = true
 }
+
+variable "timestamp_uptime_check_period" {
+  type    = string
+  default = "60s"
+}
+
+variable "timestamp_url" {
+  description = "Timestamp Authority URL"
+  type        = string
+  default     = "timestamp.sigstore.dev"
+}
+
+variable "fulcio_uptime_check_period" {
+  type    = string
+  default = "60s"
+}
+
+variable "fulcio_url" {
+  description = "Fulcio URL"
+  type        = string
+  default     = "fulcio.sigstore.dev"
+}
+
+variable "notification_channel_ids" {
+  description = "List of notification channel IDs which alerts should be sent to. You can find this by running `gcloud alpha monitoring channels list`."
+  type        = list(string)
+  default     = []
+}


### PR DESCRIPTION
# Add uptime checks for global tiles logs

The active_shard monitoring modules already monitor the uptime of
individual shards, but we need new monitoring to monitor the uptime of,
e.g. global.ctfe.sigstage.dev.

# Make fulcio and TSA uptime checks global

These uptime checks are using the global URL (e.g. fulcio.sigstage.dev)
and there are no region-specific URLs for fulcio and TSA. Move these to
a global module so they are only instantiated once, but with backwards
compatibility for single-region systems.

Relates to https://github.com/sigstore/public-good-instance/issues/3603
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
