### PR TITLE
Make mix/max gke node counts more configurable

### DIFF
--- a/gcp/modules/gke_cluster/node_pool.tf
+++ b/gcp/modules/gke_cluster/node_pool.tf
@@ -33,9 +33,15 @@ resource "google_container_node_pool" "cluster_nodes" {
     ]
   }
 
-  autoscaling {
-    min_node_count = var.autoscaling_min_node
-    max_node_count = var.autoscaling_max_node
+  dynamic "autoscaling" {
+    for_each = (var.autoscaling_min_node != null || var.autoscaling_max_node != null) ? [1] : []
+
+    content {
+      min_node_count       = var.autoscaling_scope == "ZONE" ? var.autoscaling_min_node : null
+      max_node_count       = var.autoscaling_scope == "ZONE" ? var.autoscaling_max_node : null
+      total_min_node_count = var.autoscaling_scope == "CLUSTER" ? var.autoscaling_min_node : null
+      total_max_node_count = var.autoscaling_scope == "CLUSTER" ? var.autoscaling_max_node : null
+    }
   }
 
   management {

--- a/gcp/modules/gke_cluster/variables.tf
+++ b/gcp/modules/gke_cluster/variables.tf
@@ -189,6 +189,17 @@ variable "autoscaling_max_node" {
   default = 10
 }
 
+variable "autoscaling_scope" {
+  type        = string
+  description = "The scope of autoscaling min/max node limits: ZONE (per zone) or CLUSTER (total across all zones)."
+  default     = "ZONE"
+
+  validation {
+    condition     = contains(["ZONE", "CLUSTER"], var.autoscaling_scope)
+    error_message = "autoscaling_scope must be either 'ZONE' or 'CLUSTER'."
+  }
+}
+
 variable "initial_node_count" {
   type    = number
   default = 3

--- a/gcp/modules/sigstore/sigstore.tf
+++ b/gcp/modules/sigstore/sigstore.tf
@@ -177,6 +177,7 @@ module "gke-cluster" {
   initial_node_count   = var.initial_node_count
   autoscaling_min_node = var.autoscaling_min_node
   autoscaling_max_node = var.autoscaling_max_node
+  autoscaling_scope    = var.autoscaling_scope
 
   node_config_machine_type = var.gke_node_config_machine_type
 

--- a/gcp/modules/sigstore/variables.tf
+++ b/gcp/modules/sigstore/variables.tf
@@ -259,6 +259,17 @@ variable "autoscaling_max_node" {
   default = 10
 }
 
+variable "autoscaling_scope" {
+  type        = string
+  description = "The scope of autoscaling min/max node limits: ZONE (per zone) or CLUSTER (total across all zones)."
+  default     = "ZONE"
+
+  validation {
+    condition     = contains(["ZONE", "CLUSTER"], var.autoscaling_scope)
+    error_message = "autoscaling_scope must be either 'ZONE' or 'CLUSTER'."
+  }
+}
+
 variable "gke_autoscaling_resource_limits_resource_cpu_max" {
   type    = number
   default = 4


### PR DESCRIPTION

#### Summary
Allows us to set overall cluster node min / max instead of per zone

A selector allows configuration to chose zonal or cluster level limits. The current behavior shouldn't change unless a user overrides the autoscaling_scope var

This is a follow up to https://github.com/sigstore/public-good-instance/blob/main/incidents/2026-06-09-rekor-server-resource-constraints.md (access controlled link)

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
