### PR TITLE
switch cluster to container metric for tesseract

### DIFF
--- a/gcp/modules/monitoring/tesseract/active_shard/slo.tf
+++ b/gcp/modules/monitoring/tesseract/active_shard/slo.tf
@@ -28,7 +28,7 @@ module "slos" {
   availability_slos = {
     http-server-availability = {
       display_prefix            = "Availability (HTTP Server)"
-      base_total_service_filter = "metric.type=\"workload.googleapis.com/tesseract.http.response.count\" resource.type=\"k8s_cluster\""
+      base_total_service_filter = "metric.type=\"workload.googleapis.com/tesseract.http.response.count\" resource.type=\"k8s_container\""
       # Only count 500s as server errors since clients can trigger 400s.
       bad_filter = "metric.labels.http_response_status_code=monitoring.regex.full_match(\"5[0-9][0-9]\")"
       slos = {

--- a/gcp/modules/monitoring/tesseract/active_shard/tesseract.json.tpl
+++ b/gcp/modules/monitoring/tesseract/active_shard/tesseract.json.tpl
@@ -14,8 +14,11 @@
             "timeSeriesFilter": {
               "aggregation": {
                 "alignmentPeriod": "60s",
-                "crossSeriesReducer": "REDUCE_SUM",
-                "perSeriesAligner": "ALIGN_MEAN"
+                "crossSeriesReducer": "REDUCE_MEAN",
+                "perSeriesAligner": "ALIGN_MEAN",
+                "groupByFields": [
+                  "metric.label.\"service_name\""
+                ],
               },
               "filter": "metric.type=\"workload.googleapis.com/tessera.appender.integrated.size\" resource.type=\"k8s_container\""
             }

--- a/gcp/modules/monitoring/tesseract/active_shard/tesseract.json.tpl
+++ b/gcp/modules/monitoring/tesseract/active_shard/tesseract.json.tpl
@@ -18,7 +18,7 @@
                 "perSeriesAligner": "ALIGN_MEAN",
                 "groupByFields": [
                   "metric.label.\"service_name\""
-                ],
+                ]
               },
               "filter": "metric.type=\"workload.googleapis.com/tessera.appender.integrated.size\" resource.type=\"k8s_container\""
             }

--- a/gcp/modules/monitoring/tesseract/active_shard/tesseract.json.tpl
+++ b/gcp/modules/monitoring/tesseract/active_shard/tesseract.json.tpl
@@ -17,7 +17,7 @@
                 "crossSeriesReducer": "REDUCE_SUM",
                 "perSeriesAligner": "ALIGN_MEAN"
               },
-              "filter": "metric.type=\"workload.googleapis.com/tessera.appender.integrated.size\" resource.type=\"k8s_cluster\""
+              "filter": "metric.type=\"workload.googleapis.com/tessera.appender.integrated.size\" resource.type=\"k8s_container\""
             }
           }
         }
@@ -43,7 +43,7 @@
                     ],
                     "perSeriesAligner": "ALIGN_RATE"
                   },
-                  "filter": "metric.type=\"workload.googleapis.com/tesseract.http.request.count\" resource.type=\"k8s_cluster\""
+                  "filter": "metric.type=\"workload.googleapis.com/tesseract.http.request.count\" resource.type=\"k8s_container\""
                 }
               }
             }
@@ -71,7 +71,7 @@
                     "crossSeriesReducer": "REDUCE_SUM",
                     "perSeriesAligner": "ALIGN_DELTA"
                   },
-                  "filter": "metric.type=\"workload.googleapis.com/tesseract.http.request.duration\" resource.type=\"k8s_cluster\""
+                  "filter": "metric.type=\"workload.googleapis.com/tesseract.http.request.duration\" resource.type=\"k8s_container\""
                 }
               }
             }


### PR DESCRIPTION
with https://github.com/sigstore/helm-charts/pull/1196 merged metrics are now persisted at the container level instead of at the cluster level. this updates the tesseract SLO and dashboards accordingly.