### PR TITLE
Unify tiles logs under composite modules

### DIFF
--- a/gcp/modules/sigstore/sigstore.tf
+++ b/gcp/modules/sigstore/sigstore.tf
@@ -567,3 +567,178 @@ module "dex" {
     module.project_roles
   ]
 }
+
+// Rekor Tiles Shards
+module "rekor_tiles" {
+  for_each = var.rekor_tiles_shards
+
+  source = "../tiles_tlog"
+
+  shard_name = each.key
+
+  freeze_shard        = each.value.freeze_shard
+  lb_backend_turndown = each.value.lb_backend_turndown
+
+  project_id     = var.project_id
+  project_number = var.project_number
+  region         = var.region
+  cluster_name   = var.cluster_name
+
+  cluster_namespace_suffix = each.value.cluster_namespace_suffix
+  cluster_service_account  = "rekor-tiles"
+
+  bucket_name_suffix = each.value.bucket_name_suffix
+  bucket_id_length   = each.value.bucket_id_length
+
+  spanner_processing_units             = each.value.spanner_processing_units
+  spanner_instance_name_suffix         = each.value.spanner_instance_name_suffix
+  spanner_instance_display_name_suffix = each.value.spanner_instance_display_name_suffix
+
+  keyring_name_suffix = each.value.keyring_name_suffix
+  key_name            = each.value.key_name
+
+  dns_zone_name      = var.dns_zone_name
+  dns_domain_name    = var.dns_domain_name
+  dns_subdomain_name = each.value.dns_subdomain_name
+
+  http_grpc_qpm_rate_limit           = each.value.http_grpc_qpm_rate_limit
+  max_req_content_length             = each.value.max_req_content_length
+  max_req_content_length_description = each.value.max_req_content_length_description
+
+  network_endpoint_group_http_name_suffix = each.value.network_endpoint_group_http_name_suffix
+  network_endpoint_group_grpc_name_suffix = each.value.network_endpoint_group_grpc_name_suffix
+  network_endpoint_group_zones            = each.value.network_endpoint_group_zones
+
+  http_write_path        = "/api/v2/log/entries"
+  grpc_write_path        = "/dev.sigstore.rekor.v2.Rekor/CreateEntry"
+  http_read_path         = "/api/v2/{path=**}"
+  http_read_rewrite_path = "/{path}"
+
+  http_health_check_id      = var.rekor_http_health_check_id
+  grpc_health_check_id      = var.rekor_grpc_health_check_id
+  security_policy_id        = var.rekor_security_policy_id
+  bucket_security_policy_id = var.rekor_bucket_security_policy_id
+  ssl_policy_id             = var.rekor_ssl_policy_id
+
+  spanner_timeseries_role_id = "SpannerMonitoringTimeseries"
+  monitoring_role_id         = "OTelMetrics"
+
+  spanner_database_sequencer_deletion_protection = each.value.spanner_database_sequencer_deletion_protection
+  spanner_database_antispam_deletion_protection  = each.value.spanner_database_antispam_deletion_protection
+
+  single_region = each.value.single_region
+
+  depends_on = [
+    module.gke-cluster,
+    module.network,
+    module.project_roles
+  ]
+}
+
+module "rekor_monitoring" {
+  for_each = {
+    for k, v in var.rekor_tiles_shards : k => v
+    if !v.freeze_shard && lookup(v, "enable_monitoring", true)
+  }
+
+  source = "../monitoring/rekorv2/active_shard"
+
+  shard_name = each.key
+
+  project_id           = var.project_id
+  project_number       = var.project_number
+  cluster_location     = var.region
+  cluster_name         = var.cluster_name
+  gke_namespace_suffix = each.value.cluster_namespace_suffix
+  rekor_url            = each.value.rekor_url
+  spanner_instance_id  = each.value.spanner_instance_id != null && each.value.spanner_instance_id != "" ? each.value.spanner_instance_id : module.rekor_tiles[each.key].spanner_instance_id
+
+  notification_channel_ids = var.monitoring.notification_channel_ids
+  create_slos              = var.create_slos
+}
+
+// CTLog Tiles Shards
+module "ctlog_tiles" {
+  for_each = var.ctlog_tiles_shards
+
+  source = "../tiles_tlog"
+
+  shard_name = each.key
+
+  lb_backend_turndown = each.value.lb_backend_turndown
+  freeze_shard        = each.value.freeze_shard
+
+  project_id     = var.project_id
+  project_number = var.project_number
+  region         = var.region
+  cluster_name   = var.cluster_name
+
+  cluster_namespace_suffix = each.value.cluster_namespace_suffix
+  cluster_service_account  = "ctlog-tiles"
+
+  bucket_name_suffix = each.value.bucket_name_suffix
+  bucket_id_length   = each.value.bucket_id_length
+
+  spanner_processing_units             = each.value.spanner_processing_units
+  spanner_instance_name_suffix         = each.value.spanner_instance_name_suffix
+  spanner_instance_display_name_suffix = each.value.spanner_instance_display_name_suffix
+
+  # TesseraCT uses Secret Manager instead of KMS
+  keyring_name_suffix = ""
+  enable_secrets      = true
+
+  dns_zone_name      = var.dns_zone_name
+  dns_domain_name    = var.dns_domain_name
+  dns_subdomain_name = each.value.dns_subdomain_name
+
+  http_grpc_qpm_rate_limit           = each.value.http_grpc_qpm_rate_limit
+  max_req_content_length             = each.value.max_req_content_length
+  max_req_content_length_description = each.value.max_req_content_length_description
+
+  network_endpoint_group_http_name_suffix = each.value.network_endpoint_group_http_name_suffix
+  network_endpoint_group_zones            = each.value.network_endpoint_group_zones
+
+  http_write_path           = "/ct/v1/get-roots"
+  http_read_path            = "/checkpoint"
+  http_health_check_id      = var.ctlog_http_health_check_id
+  security_policy_id        = var.ctlog_security_policy_id
+  bucket_security_policy_id = var.ctlog_bucket_security_policy_id
+  ssl_policy_id             = var.ctlog_ssl_policy_id
+
+  spanner_timeseries_role_id = "SpannerMonitoringTimeseries"
+  monitoring_role_id         = "OTelMetrics"
+
+  spanner_database_sequencer_deletion_protection = each.value.spanner_database_sequencer_deletion_protection
+  spanner_database_antispam_deletion_protection  = each.value.spanner_database_antispam_deletion_protection
+
+  single_region = each.value.single_region
+
+  depends_on = [
+    module.gke-cluster,
+    module.network,
+    module.project_roles
+  ]
+}
+
+module "ctlog_monitoring" {
+  for_each = {
+    for k, v in var.ctlog_tiles_shards : k => v
+    if !v.freeze_shard && lookup(v, "enable_monitoring", true)
+  }
+
+  source = "../monitoring/tesseract/active_shard"
+
+  shard_name = each.key
+
+  project_id           = var.project_id
+  project_number       = var.project_number
+  cluster_location     = var.region
+  cluster_name         = var.cluster_name
+  gke_namespace_suffix = each.value.cluster_namespace_suffix
+  ctlog_url            = each.value.ctlog_url
+  spanner_instance_id  = each.value.spanner_instance_id != null && each.value.spanner_instance_id != "" ? each.value.spanner_instance_id : module.ctlog_tiles[each.key].spanner_instance_id
+
+  notification_channel_ids = var.monitoring.notification_channel_ids
+  create_slos              = var.create_slos
+}
+

--- a/gcp/modules/sigstore/variables.tf
+++ b/gcp/modules/sigstore/variables.tf
@@ -892,6 +892,126 @@ variable "dex_enable_ssl_policy" {
 }
 
 /********************************/
+/******* REKOR v2 TILES *********/
+/********************************/
+
+variable "rekor_tiles_shards" {
+  type = map(object({
+    cluster_namespace_suffix                       = string
+    bucket_name_suffix                             = string
+    spanner_processing_units                       = optional(number)
+    spanner_instance_name_suffix                   = string
+    spanner_instance_display_name_suffix           = string
+    network_endpoint_group_http_name_suffix        = string
+    network_endpoint_group_grpc_name_suffix        = string
+    network_endpoint_group_zones                   = optional(list(string), [])
+    rekor_url                                      = optional(string)
+    freeze_shard                                   = optional(bool, false)
+    lb_backend_turndown                            = optional(bool, false)
+    bucket_id_length                               = optional(number, 10)
+    spanner_database_sequencer_deletion_protection = optional(bool, true)
+    spanner_database_antispam_deletion_protection  = optional(bool, true)
+    http_grpc_qpm_rate_limit                       = optional(number, 600)
+    max_req_content_length                         = optional(number, 102400)
+    max_req_content_length_description             = optional(string, "100KiB")
+    keyring_name_suffix                            = optional(string, "rekor-tiles-keyring")
+    dns_subdomain_name                             = optional(string, "rekor")
+    single_region                                  = optional(bool, true)
+    key_name                                       = optional(string, "checkpoint-signer-key-encryption-key")
+    spanner_instance_id                            = optional(string)
+    enable_monitoring                              = optional(bool, true)
+  }))
+  description = "Map of Rekor shards to dynamically instantiate"
+  default     = {}
+}
+
+variable "ctlog_tiles_shards" {
+  type = map(object({
+    cluster_namespace_suffix                       = string
+    bucket_name_suffix                             = string
+    spanner_processing_units                       = optional(number)
+    spanner_instance_name_suffix                   = string
+    spanner_instance_display_name_suffix           = string
+    network_endpoint_group_http_name_suffix        = string
+    network_endpoint_group_grpc_name_suffix        = optional(string)
+    network_endpoint_group_zones                   = optional(list(string), [])
+    ctlog_url                                      = optional(string)
+    freeze_shard                                   = optional(bool, false)
+    lb_backend_turndown                            = optional(bool, false)
+    bucket_id_length                               = optional(number, 10)
+    spanner_database_sequencer_deletion_protection = optional(bool, true)
+    spanner_database_antispam_deletion_protection  = optional(bool, true)
+    http_grpc_qpm_rate_limit                       = optional(number, 600)
+    max_req_content_length                         = optional(number, 102400)
+    max_req_content_length_description             = optional(string, "100KiB")
+    dns_subdomain_name                             = optional(string, "ctfe")
+    single_region                                  = optional(bool, true)
+    spanner_instance_id                            = optional(string)
+    enable_monitoring                              = optional(bool, true)
+  }))
+  description = "Map of CTLog shards to dynamically instantiate"
+  default     = {}
+}
+
+/********************************/
+/**** SHARD GLOBAL RESOURCES ****/
+/********************************/
+
+variable "rekor_http_health_check_id" {
+  type        = string
+  description = "Global Rekor HTTP Health Check ID"
+  default     = null
+}
+
+variable "rekor_grpc_health_check_id" {
+  type        = string
+  description = "Global Rekor gRPC Health Check ID"
+  default     = null
+}
+
+variable "rekor_security_policy_id" {
+  type        = string
+  description = "Global Rekor Security Policy ID"
+  default     = null
+}
+
+variable "rekor_bucket_security_policy_id" {
+  type        = string
+  description = "Global Rekor Bucket Security Policy ID"
+  default     = null
+}
+
+variable "rekor_ssl_policy_id" {
+  type        = string
+  description = "Global Rekor SSL Policy ID"
+  default     = null
+}
+
+variable "ctlog_http_health_check_id" {
+  type        = string
+  description = "Global CTLog HTTP Health Check ID"
+  default     = null
+}
+
+variable "ctlog_security_policy_id" {
+  type        = string
+  description = "Global CTLog Security Policy ID"
+  default     = null
+}
+
+variable "ctlog_bucket_security_policy_id" {
+  type        = string
+  description = "Global CTLog Bucket Security Policy ID"
+  default     = null
+}
+
+variable "ctlog_ssl_policy_id" {
+  type        = string
+  description = "Global CTLog SSL Policy ID"
+  default     = null
+}
+
+/********************************/
 /********** VALIDATION **********/
 /********************************/
 

--- a/gcp/modules/sigstore_global/global.tf
+++ b/gcp/modules/sigstore_global/global.tf
@@ -110,3 +110,38 @@ module "timestamp_monitoring" {
   uptime_check_period      = var.timestamp_uptime_check_period
   notification_channel_ids = var.notification_channel_ids
 }
+
+module "rekor_tiles_global" {
+  source = "../tiles_tlog/global"
+
+  project_id         = var.project_id
+  dns_zone_name      = var.dns_zone_name
+  dns_domain_name    = var.dns_domain_name
+  dns_subdomain_name = var.rekor_tiles_dns_subdomain_name
+
+  active_http_negs = var.rekor_tiles_http_negs
+  active_grpc_negs = var.rekor_tiles_grpc_negs
+
+  http_write_path = "/api/v2/log/entries"
+  grpc_write_path = "/dev.sigstore.rekor.v2.Rekor/CreateEntry"
+}
+
+module "ctlog_tiles_shared" {
+  source = "../tiles_tlog/shared"
+
+  project_id         = var.project_id
+  dns_subdomain_name = var.ctlog_tiles_dns_subdomain_name
+}
+
+module "monitoring_rekorv2_lb_all" {
+  source = "../monitoring/rekorv2/lb"
+
+  project_id               = var.project_id
+  project_number           = var.project_number
+  active_shards            = var.rekor_tiles_active_shards
+  frozen_shards            = var.rekor_tiles_frozen_shards
+  notification_channel_ids = var.notification_channel_ids
+  create_slos              = var.rekor_tiles_create_slos
+  rekor_global_url         = "${var.rekor_tiles_dns_subdomain_name}.${trimsuffix(var.dns_domain_name, ".")}"
+  uptime_check_period      = var.rekor_tiles_uptime_check_period
+}

--- a/gcp/modules/sigstore_global/outputs.tf
+++ b/gcp/modules/sigstore_global/outputs.tf
@@ -1,0 +1,65 @@
+/**
+ * Copyright 2026 The Sigstore Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+output "rekor_http_health_check_id" {
+  description = "The HTTP health check ID for the global Rekor LBs."
+  value       = module.rekor_tiles_global.http_health_check_id
+}
+
+output "rekor_grpc_health_check_id" {
+  description = "The gRPC health check ID for the global Rekor LBs."
+  value       = module.rekor_tiles_global.grpc_health_check_id
+}
+
+output "rekor_security_policy_id" {
+  description = "The security policy ID for the global Rekor LBs."
+  value       = module.rekor_tiles_global.security_policy_id
+}
+
+output "rekor_bucket_security_policy_id" {
+  description = "The bucket security policy ID for the global Rekor LBs."
+  value       = module.rekor_tiles_global.bucket_security_policy_id
+}
+
+output "rekor_ssl_policy_id" {
+  description = "The SSL policy ID for the global Rekor LBs."
+  value       = module.rekor_tiles_global.ssl_policy_id
+}
+
+output "ctlog_http_health_check_id" {
+  description = "The HTTP health check ID for the shared CTLog LBs."
+  value       = module.ctlog_tiles_shared.http_health_check_id
+}
+
+output "ctlog_grpc_health_check_id" {
+  description = "The gRPC health check ID for the shared CTLog LBs."
+  value       = module.ctlog_tiles_shared.grpc_health_check_id
+}
+
+output "ctlog_security_policy_id" {
+  description = "The security policy ID for the shared CTLog LBs."
+  value       = module.ctlog_tiles_shared.security_policy_id
+}
+
+output "ctlog_bucket_security_policy_id" {
+  description = "The bucket security policy ID for the shared CTLog LBs."
+  value       = module.ctlog_tiles_shared.bucket_security_policy_id
+}
+
+output "ctlog_ssl_policy_id" {
+  description = "The SSL policy ID for the shared CTLog LBs."
+  value       = module.ctlog_tiles_shared.ssl_policy_id
+}

--- a/gcp/modules/sigstore_global/variables.tf
+++ b/gcp/modules/sigstore_global/variables.tf
@@ -214,3 +214,62 @@ variable "notification_channel_ids" {
   type        = list(string)
   default     = []
 }
+
+variable "rekor_tiles_http_negs" {
+  type = list(object({
+    name = string
+    zone = string
+  }))
+  description = "List of objects containing the names and zones of active HTTP NEGs across all shards and regions to route write traffic to."
+  default     = []
+}
+
+variable "rekor_tiles_grpc_negs" {
+  type = list(object({
+    name = string
+    zone = string
+  }))
+  description = "List of objects containing the names and zones of active gRPC NEGs across all shards and regions to route write traffic to."
+  default     = []
+}
+
+variable "rekor_tiles_dns_subdomain_name" {
+  description = "DNS subdomain name for global Rekor"
+  type        = string
+  default     = "global.rekor"
+}
+
+variable "ctlog_tiles_dns_subdomain_name" {
+  description = "DNS subdomain name for global CTLog"
+  type        = string
+  default     = "global.ctfe"
+}
+
+variable "project_number" {
+  type    = string
+  default = ""
+}
+
+variable "rekor_tiles_active_shards" {
+  description = "List of active Rekor v2 shard names to monitor."
+  type        = list(string)
+  default     = []
+}
+
+variable "rekor_tiles_frozen_shards" {
+  description = "List of frozen Rekor v2 shard names to monitor."
+  type        = list(string)
+  default     = []
+}
+
+variable "rekor_tiles_create_slos" {
+  description = "True to enable Rekor tiles global LB SLO creation."
+  type        = bool
+  default     = true
+}
+
+variable "rekor_tiles_uptime_check_period" {
+  description = "Uptime check period for the global Rekor tiles LB."
+  type        = string
+  default     = "60s"
+}

--- a/gcp/modules/tiles_tlog/outputs.tf
+++ b/gcp/modules/tiles_tlog/outputs.tf
@@ -23,3 +23,8 @@ output "grpc_neg_name" {
   description = "Name of the gRPC Network Endpoint Group"
   value       = var.network_endpoint_group_grpc_name_suffix != "" ? "${var.shard_name}-${var.network_endpoint_group_grpc_name_suffix}" : ""
 }
+
+output "spanner_instance_id" {
+  description = "Name of the Spanner Instance"
+  value       = var.freeze_shard ? "" : google_spanner_instance.tessera[0].name
+}


### PR DESCRIPTION
# Instantiate tiles_tlog modules from sigstore

The tiles_tlog modules and their associated monitoring modules have been
managed outside of the composite sigstore module and also managed
individually with one module instantiation per shard. The reason for
this is to allow for the possibility that each shard may use a
different terraform-modules reference if needed.

This has never been needed, and it would be bad practice to let the
versions skew apart from each other. Statically instantiating each shard
as its own module means an enormous amount of duplication, which hinders
maintenance. In the root module in public-good-instance, it also adds to
an awkward split between variables and hardcoded values in the .tf
files, for instance using 'local.east_region' instead of being able to
iterate over regions.

This commit adds the ability to dynamically manage all shards from the
sigstore module as a unified entrypoint. This obligates us to use the
same terraform-modules reference for tiles shards as for all the rest of
the sigstore infrastructure and making changes across modules be
compatible with each other, which we have been successful at so far. It
will allow us to clean up hard-coded values for shards in
public-good-instance .tf files.

# Fold global tlog resources under sigstore_global

With per-region tlog shards now configurable through the composite
sigstore module, it makes sense to unify the control plane resources for
tlogs under the global module for an opinionated infrastructure config.
The entrypoint to deploy a full sigstore instance is now simply one
sigstore_global instance for the control plane and N sigstore instances
for N regions.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
